### PR TITLE
OO.extend() refactor

### DIFF
--- a/basics/oo.js
+++ b/basics/oo.js
@@ -18,10 +18,15 @@ var defaultKeyProps = {'name': true, 'displayName': true};
 var _inherit;
 
 var extend = function(parent, keyProps, afterHook, proto) {
+  if (arguments.length > 4) {
+    var args = Array.prototype.slice.apply(arguments, 3);
+    proto = _.extend.apply(null, args);
+  }
   var Constructor = function ExtendedClass() {
     this.__className__ = proto.displayName || proto.name;
     parent.apply(this, arguments);
     if (this.init) {
+      console.log('DEPRECATED: we want to drop this built-in hook in favor of a custom hook.');
       this.init.apply(this, arguments);
     }
   };

--- a/basics/oo.js
+++ b/basics/oo.js
@@ -19,7 +19,7 @@ var _inherit;
 
 var extend = function(parent, keyProps, afterHook, proto) {
   if (arguments.length > 4) {
-    var args = Array.prototype.slice.apply(arguments, 3);
+    var args = Array.prototype.slice.call(arguments, 3);
     proto = _.extend.apply(null, args);
   }
   var Constructor = function ExtendedClass() {

--- a/data/node.js
+++ b/data/node.js
@@ -24,6 +24,8 @@ function Node( properties ) {
   this.properties = _.extend({}, this.getDefaultProperties(), properties);
   this.properties.type = this.constructor.static.name;
   this.properties.id = this.properties.id || uuid(this.properties.type);
+
+  this.didInitialize();
 }
 
 Node.Prototype = function() {
@@ -37,6 +39,8 @@ Node.Prototype = function() {
     type: 'string',
     id: 'string'
   };
+
+  this.didInitialize = function() {};
 
   /**
    * Serialize to JSON.

--- a/document/container.js
+++ b/document/container.js
@@ -41,6 +41,10 @@ function Container() {
 
 Container.Prototype = function() {
 
+  this.properties = {
+    nodes: ["array", "string"]
+  };
+
   this.didAttach = function() {
     this.reset();
   };
@@ -320,13 +324,6 @@ Container.Prototype = function() {
 OO.inherit(Container, Node);
 
 Container.static.name = "container";
-
-Container.static.schema = {
-  nodes: ["array", "string"]
-};
-
-// HACK: ATM we do a lot of Node initialization, but we only do it using Node.extend(..)
-Node.initNodeClass(Container);
 
 Container.Component = function Component(path, rootId) {
   this.path = path;

--- a/document/node.js
+++ b/document/node.js
@@ -94,8 +94,6 @@ var Node = Data.Node.extend({
 
 });
 
-Node.initNodeClass = Data.Node.initNodeClass;
-
 // default HTML serialization
 Node.static.toHtml = function(node, converter) {
   var $el = $('<div itemscope>')


### PR DESCRIPTION
Improved to make it easier to customize the extend implementation.
Plus: now OO.extend() allows for mixins.
