### PR TITLE
OO.extend() and OO.inherit() support static properties.

### DIFF
--- a/data/node.js
+++ b/data/node.js
@@ -195,6 +195,7 @@ var initNodeClass = function(NodeClass, proto) {
       NodeClass.static.schema = proto.properties;
     }
   } else {
+    // TODO: we should use static.properties for sake of consistency
     if (NodeClass.prototype.hasOwnProperty('properties')) {
       NodeClass.static.schema = NodeClass.prototype.properties;
     }

--- a/test/unit/basics/oo.test.js
+++ b/test/unit/basics/oo.test.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var OO = require('../../../basics/oo');
+
+QUnit.module('Substance.OO');
+
+QUnit.test("OO.extend and OO.inherit should propagate static properties", function(assert) {
+  function A() {}
+  OO.makeExtensible(A, {'name': true});
+
+  var B = A.extend({
+    name: "foo"
+  });
+  assert.equal(B.static.name, 'foo', 'B should have static name "foo".');
+
+  function C() {}
+  C.Prototype = function() {
+    this.name = "foo";
+  };
+  OO.inherit(C, A);
+  assert.equal(C.static.name, 'foo', 'C should have static name "foo".');
+});
+
+QUnit.test("OO.extend and OO.inherit should use proto.static", function(assert) {
+  function A() {}
+  OO.makeExtensible(A);
+
+  var B = A.extend({
+    static: {
+      foo: 'bar'
+    }
+  });
+  assert.equal(B.static.foo, 'bar', 'B should have static property "foo".');
+
+  function C() {}
+  C.Prototype = function() {
+    this.static = {
+      foo: "bar"
+    };
+  };
+  OO.inherit(C, A);
+  assert.equal(C.static.foo, 'bar', 'C should have static property "foo".');
+});


### PR DESCRIPTION
- either defined using OO.makeExtensible(clazz, staticProperties)
- or via proto.static = {...}

Look at test (oo.test.js) for usage.
