### PR TITLE
Writer Refactor

### DIFF
--- a/document/annotation.js
+++ b/document/annotation.js
@@ -62,15 +62,7 @@ var Annotation = Node.extend({
     }
     var text = doc.get(this.path);
     return text.substring(this.startOffset, this.endOffset);
-  },
-
-  // volatile property necessary to render highlighted annotations differently
-  setActive: function(val) {
-    if (this.active !== val) {
-      this.active = val;
-      this.emit('active', val);
-    }
-  },
+  }
 
 });
 

--- a/document/document.js
+++ b/document/document.js
@@ -277,6 +277,33 @@ Document.Prototype = function() {
     return new ClipboardExporter();
   };
 
+  this.getHighlights = function() {
+    return this._highlights;
+  };
+
+  // Set higlights on a document
+  this.setHighlights = function(highlights) {
+    var oldHighlights = this._highlights;
+
+    if (oldHighlights) {
+      _.each(oldHighlights, function(nodeId) {
+        var node = this.get(nodeId);
+        // Node could in the meanwhile have been deleted
+        if (node) {
+          node.setHighlighted(false);  
+        }
+      }, this);
+    }
+
+    _.each(highlights, function(nodeId) {
+      var node = this.get(nodeId);
+      node.setHighlighted(true);
+    }, this);
+
+    this._highlights = highlights;
+    this.emit('highlights:updated', highlights);
+  };
+
   /**
    * Enable or disable auto-attaching of nodes.
    * When this is enabled (default), a created node
@@ -289,7 +316,6 @@ Document.Prototype = function() {
     Document.super.prototype._setAutoAttach.call(this, val);
     this.stage._setAutoAttach(val);
   };
-
 
   this._saveTransaction = function(beforeState, afterState, info) {
     // var time = Date.now();

--- a/document/html_importer.js
+++ b/document/html_importer.js
@@ -134,7 +134,8 @@ HtmlImporter.Prototype = function HtmlImporterPrototype() {
     // create annotations afterwards so that the targeted nodes
     // exist for sure
     for (var i = 0; i < this.state.inlineNodes.length; i++) {
-      doc.create(this.state.inlineNodes[i]);
+      var anno = this.state.inlineNodes[i];
+      doc.create(anno);
     }
   };
 
@@ -406,7 +407,7 @@ HtmlImporter.Prototype = function HtmlImporterPrototype() {
         // in the mean time the offset will probably have changed to reentrant calls
         var endOffset = context.offset;
         inlineNode.type = inlineType.static.name;
-        inlineNode.id = inlineType.id || this.nextId(inlineNode.type);
+        inlineNode.id = inlineNode.id || this.nextId(inlineNode.type);
         inlineNode.startOffset = startOffset;
         inlineNode.endOffset = endOffset;
         inlineNode.path = context.path.slice(0);

--- a/document/node.js
+++ b/document/node.js
@@ -57,6 +57,14 @@ var Node = Data.Node.extend({
     return componentNames;
   },
 
+  // volatile property necessary to render highlighted node differently
+  setHighlighted: function(highlighted) {
+    if (this.highlighted !== highlighted) {
+      this.highlighted = highlighted;
+      this.emit('highlighted', highlighted);
+    }
+  },
+
   isExternal: function() {
     return this.constructor.static.external;
   },

--- a/ui/nodes/annotation_component.js
+++ b/ui/nodes/annotation_component.js
@@ -14,8 +14,8 @@ AnnotationComponent.Prototype = function() {
     var el = $$('span')
       .attr("data-id", this.props.node.id)
       .addClass(this.getClassNames());
-    if (this.props.node.active) {
-      el.addClass('active');
+    if (this.props.node.highlighted) {
+      el.addClass('highlighted');
     }
     el.append(this.props.children);
     return el;
@@ -33,7 +33,7 @@ AnnotationComponent.Prototype = function() {
   this.didMount = function() {
     var node = this.props.node;
     node.connect(this, {
-      'active': this.onActiveChanged
+      'highlighted': this.onHighlightedChanged
     });
   };
 
@@ -42,11 +42,11 @@ AnnotationComponent.Prototype = function() {
     node.disconnect(this);
   };
 
-  this.onActiveChanged = function() {
-    if (this.props.node.active) {
-      this.$el.addClass('active');
+  this.onHighlightedChanged = function() {
+    if (this.props.node.highlighted) {
+      this.$el.addClass('highlighted');
     } else {
-      this.$el.removeClass('active');
+      this.$el.removeClass('highlighted');
     }
   };
 };

--- a/ui/nodes/container_node_component.js
+++ b/ui/nodes/container_node_component.js
@@ -86,8 +86,9 @@ ContainerNodeComponent.Prototype = function() {
     var options = {
       name: this.props.node.id,
       logger: this.context.notifications,
-      commands: this.props.commands
+      commands: this.props.commands || this.context.commands
     };
+
     this.surface = new Surface(this.context.surfaceManager, doc, editor, options);
   };
 };

--- a/ui/styles/modules/toc_panel.scss
+++ b/ui/styles/modules/toc_panel.scss
@@ -1,0 +1,37 @@
+
+/* TOC Panel
+-----------------------------------------------------*/
+
+.toc-panel-component .toc-entries {
+  padding: 20px 0px;
+}
+
+.toc-panel-component .toc-entry {
+  color: #777;
+  font-weight: 600;
+  display: block;
+  padding: 5px 0px;
+}
+
+.toc-panel-component .toc-entry.active {
+  color: #222;
+}
+
+.toc-panel-component .toc-entry:hover {
+  color: #444;
+}
+
+.toc-panel-component .toc-entry.level-1 {
+  font-size: 20px;
+  padding-left: 20px;
+}
+
+.toc-panel-component .toc-entry.level-2 {
+  font-size: 18px;
+  padding-left: 40px;
+}
+
+.toc-panel-component .toc-entry.level-3 {
+  font-size: 16px;
+  padding-left: 60px;
+}

--- a/ui/writer/context_toggles.js
+++ b/ui/writer/context_toggles.js
@@ -21,7 +21,7 @@ ContextToggles.Prototype = function() {
     var el = $$('div').addClass("context-toggles");
     _.each(panelOrder, function(panelId) {
       var panelClass = componentRegistry.get(panelId);
-      var toggle = $$('a').key(panelClass.contextId)
+      var toggle = $$('a')
         .addClass("toggle-context")
         .attr({
           href: "#",
@@ -38,7 +38,7 @@ ContextToggles.Prototype = function() {
         $$('span').addClass('label').append(panelClass.displayName)
       );
       el.append(toggle);
-    });
+    }, this);
     return el;
   };
 

--- a/ui/writer/extension_manager.js
+++ b/ui/writer/extension_manager.js
@@ -46,8 +46,8 @@ ExtensionManager.Prototype = function() {
   };
 
 
-  this.handleSelectionChange = function(sel) {
-    return this.handle("handleSelectionChange", sel);
+  this.handleSelectionChange = function(sel, surface) {
+    return this.handle("handleSelectionChange", sel, surface);
   };
 
   this.handleAction = function(actionName) {

--- a/ui/writer/toc_panel.js
+++ b/ui/writer/toc_panel.js
@@ -20,8 +20,9 @@ TocPanel.Prototype = function() {
     var state = this.state;
     _.each(state.tocNodes, function(node) {
       var level = node.level;
-      var tocEntry = $$('a').key(node.id)
-        .addClass("toc-entry", "level-"+level)
+      var tocEntry = $$('a')
+        .addClass('toc-entry')
+        .addClass('level-'+level)
         .attr({
           href: "#",
           "data-id": node.id,
@@ -103,7 +104,6 @@ TocPanel.Prototype = function() {
 
   this.handleClick = function(e) {
     var nodeId = e.currentTarget.dataset.id;
-    console.log('clicked', nodeId);
     e.preventDefault();
     var doc = this.getDocument();
     doc.emit("toc:entry-selected", nodeId);


### PR DESCRIPTION
Some considerations:

I think our current Writer extension mechanism is a bit over-engineered and makes things a bit intransparent for the new user. I wonder if we should consider making a step back, and put state handlers in the custom writer implementation rather than doing them within this external state handler file. I think in most cases Writer apps will be pretty custom and just tie different components together, and you make assumptions on the complete system, like sending a user to the edit citation panel in a certain condition. Often it's hard to implement handleStateChange or handleSelectionChange handlers without knowing the context (e.g. other handlers). I'm really not sure but is there a possibility that we are generally on the wrong track here, when we want to have a transparent programming interface for custom writers?

An extension mechanism would make sense more I think more for concrete implementations. E.g. LensWriter could have it's own extension mechanism.

I may be completely wrong also... I don't want to throw away what we have now... we solve many problems with it when it comes to extensions...  but I have to admit it doesn't feel very intuitive to use.
