### PR TITLE
Introducing Jsdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ node_modules
 .lock-wscript
 
 dist
-doc
+dist/doc
 test/tmp

--- a/.jsdoc
+++ b/.jsdoc
@@ -1,0 +1,3 @@
+{
+    "plugins": ["plugins/markdown"]
+}

--- a/basics/error.js
+++ b/basics/error.js
@@ -7,8 +7,8 @@ var OO = require('./oo');
  *
  * @class SubstanceError
  * @extends Error
- * @constructor
- * @module Basics
+ *
+ * @memberof module:Basics
  */
 function SubstanceError() {
   Error.apply(this, arguments);

--- a/basics/event_emitter.js
+++ b/basics/event_emitter.js
@@ -8,8 +8,7 @@ var OO = require("./oo");
  * Inspired by VisualEditor's EventEmitter class.
  *
  * @class EventEmitter
- * @constructor
- * @module Basics
+ * @memberof module:Basics
  */
 function EventEmitter() {
   this.__events__ = {};
@@ -45,6 +44,8 @@ EventEmitter.Prototype = function() {
    * @param {String} event
    * @param {Function} method
    * @param {Object} context
+   * @private
+   * @memberof module:Basics.EventEmitter.prototype
    */
   this._on = function ( event, method, context, priority) {
     var bindings;
@@ -72,6 +73,8 @@ EventEmitter.Prototype = function() {
    * @param {Function} method
    * @param {Object} context
    * @chainable
+   * @private
+   * @memberof module:Basics.EventEmitter.prototype
    */
   this._off = function ( event, method, context ) {
     var i, bindings;
@@ -104,6 +107,13 @@ EventEmitter.Prototype = function() {
     return this;
   };
 
+  /**
+   * Internal implementation of connect.
+   *
+   * @method _connect
+   * @private
+   * @memberof module:Basics.EventEmitter.prototype
+   */
   this._connect = function (obj, methods, options) {
     var priority = 0;
     if (arguments.length === 3) {
@@ -117,6 +127,13 @@ EventEmitter.Prototype = function() {
     return this;
   };
 
+  /**
+   * Internal implementation of disconnect.
+   *
+   * @method _disconnect
+   * @private
+   * @memberof module:Basics.EventEmitter.prototype
+   */
   this._disconnect = function(context) {
     var i, event, bindings;
     // Remove all connections to the context
@@ -138,6 +155,7 @@ EventEmitter.Prototype = function() {
    * Emit an event.
    *
    * @method emit
+   * @memberof module:Basics.EventEmitter.prototype
    * @param {String} event
    * @param ...arguments
    * @return true if a listener was notified, false otherwise.
@@ -172,6 +190,7 @@ EventEmitter.Prototype = function() {
    * priority earlier.
    *
    * @method emit
+   * @memberof module:Basics.EventEmitter.prototype
    * @param {Object} listener
    * @param {Object} hash with event as keys, and handler functions as values.
    * @param {Number} hash with `priority` as ordering hint (default is 0).
@@ -186,6 +205,7 @@ EventEmitter.Prototype = function() {
    * Disconnect a listener (all bindings).
    *
    * @method disconnect
+   * @memberof module:Basics.EventEmitter.prototype
    * @param {Object} listener
    * @chainable
    */
@@ -193,6 +213,15 @@ EventEmitter.Prototype = function() {
     return this._disconnect(listener);
   };
 
+  /**
+   * Subscribe a listener to a event.
+   *
+   * @param {String} event
+   * @param {Function} method
+   * @param {Object} context
+   * @param {Object} options
+   * @memberof module:Basics.EventEmitter.prototype
+   */
   this.on = function(event, method, context, options) {
     var priority = 0;
     if (arguments.length === 4) {
@@ -202,6 +231,15 @@ EventEmitter.Prototype = function() {
     this.__events__[event].sort(byPriorityDescending);
   };
 
+  /**
+   * Unsubscrive a listener from an event.
+   *
+   * @param {String} event
+   * @param {Function} method
+   * @param {Object} context
+   * @param {Object} options
+   * @memberof module:Basics.EventEmitter.prototype
+   */
   this.off = function(event, method, context) {
     /* jshint unused:false */
     // TODO: we could add sugar to be able to be able to just use

--- a/basics/factory.js
+++ b/basics/factory.js
@@ -10,8 +10,7 @@ var Registry = require('./registry');
  *
  * @class Factory
  * @extends Registry
- * @constructor
- * @module Basics
+ * @memberof module:Basics
  */
 function Factory() {
   Factory.super.call(this);
@@ -25,6 +24,7 @@ Factory.Prototype = function() {
    * @param {String} name
    * @return A new instance.
    * @method create
+   * @memberof module:Basics.Factory.prototype
    */
   this.create = function ( name ) {
     var clazz = this.get(name);

--- a/basics/helpers.js
+++ b/basics/helpers.js
@@ -3,9 +3,9 @@
 /**
  * Mostly taken from lodash.
  *
- * @class Helpers
+ * @module Basics/Helpers
  * @static
- * @module Basics
+ * @memberof module:Basics
  */
 var Helpers = {};
 

--- a/basics/index.js
+++ b/basics/index.js
@@ -8,13 +8,18 @@ var _ = require('./helpers');
  * A collection of helpers pulled together from different sources, such as lodash.
  *
  * @module Basics
- * @main Basics
  */
 var Basics = {};
 
 _.extend(Basics, require('./helpers'));
 _.extend(Basics, require('./oo'));
+
+/**
+ * @property {object} OO helper functions for object-oriented programming.
+ * @memberof module:Basics
+ */
 Basics.OO = require('./oo');
+
 Basics.PathAdapter = require('./path_adapter');
 Basics.EventEmitter = require('./event_emitter');
 Basics.Error = require('./error');

--- a/basics/oo.js
+++ b/basics/oo.js
@@ -7,9 +7,7 @@ var _ = require('./helpers');
  *
  * Inspired by VisualEditor's OO module.
  *
- * @class OO
- * @static
- * @module Basics
+ * @module Basics/OO
  */
 var OO = {};
 
@@ -102,8 +100,9 @@ var _initClass = function(clazz) {
 /**
  * Initialize a class.
  *
- * @param {Constructor} clazz
  * @method initClass
+ * @instance
+ * @param {Constructor} clazz
  */
 OO.initClass = function(clazz) {
   _initClass(clazz);
@@ -150,10 +149,10 @@ _inherit =  function(clazz, parentClazz) {
 /**
  * Inherit from a parent class.
  *
+ * @method inherit
+ * @instance
  * @param clazz {Constructor} class constructor
  * @param parentClazz {Constructor} parent constructor
- *
- * @method inherit
  */
 OO.inherit =  function(clazz, parentClazz) {
   _inherit(clazz, parentClazz);
@@ -163,9 +162,10 @@ OO.inherit =  function(clazz, parentClazz) {
 };
 
 /**
+ * @method mixin
+ * @instance
  * @param clazz {Constructor} class constructor
  * @param mixinClazz {Constructor} parent constructor
- * @method mixin
  */
 OO.mixin = function(clazz, mixinClazz) {
   var key;

--- a/basics/oo.js
+++ b/basics/oo.js
@@ -153,7 +153,21 @@ _inherit =  function(clazz, parentClazz) {
  * @instance
  * @param clazz {Constructor} class constructor
  * @param parentClazz {Constructor} parent constructor
+ * @example
+ * 
+ * var OO = require('substance/basics/oo');
+ * var Parent = function() {};
+ * Parent.Prototype = function() {
+ *   this.foo = function() { return 'foo'; } 
+ * }
+ * var Child = function() {
+ *   Parent.apply(this, arguments);
+ * }
+ * OO.inherit(Child, Parent);
+ * 
+ * 
  */
+
 OO.inherit =  function(clazz, parentClazz) {
   _inherit(clazz, parentClazz);
   if (clazz.static._afterClassInitHook) {

--- a/basics/path_adapter.js
+++ b/basics/path_adapter.js
@@ -7,8 +7,7 @@ var oo = require('./oo');
  * An adapter to access an object via path.
  *
  * @class PathAdapter
- * @module Basics
- * @constructor
+ * @memberof module:Basics
  */
 function PathAdapter(obj) {
   if (obj) {

--- a/basics/registry.js
+++ b/basics/registry.js
@@ -6,8 +6,7 @@ var oo = require('./oo');
  * Simple registry implementation.
  *
  * @class Registry
- * @constructor
- * @module Basics
+ * @memberof module:Basics
  */
 function Registry() {
   this.entries = {};
@@ -22,6 +21,7 @@ Registry.Prototype = function() {
    *
    * @param {String} name
    * @method contains
+   * @memberof module:Basics.Registry.prototype
    */
   this.contains = function(name) {
     return !!this.entries[name];
@@ -33,6 +33,7 @@ Registry.Prototype = function() {
    * @param {String} name
    * @param {Object} entry
    * @method add
+   * @memberof module:Basics.Registry.prototype
    */
   this.add = function(name, entry) {
     if (this.contains(name)) {
@@ -47,6 +48,7 @@ Registry.Prototype = function() {
    *
    * @param {String} name
    * @method remove
+   * @memberof module:Basics.Registry.prototype
    */
   this.remove = function(name) {
     var pos = this.names.indexOf(name);
@@ -56,6 +58,10 @@ Registry.Prototype = function() {
     delete this.entries[name];
   };
 
+  /**
+   * @method clear
+   * @memberof module:Basics.Registry.prototype
+   */
   this.clear = function() {
     this.names = [];
     this.entries = [];
@@ -67,6 +73,7 @@ Registry.Prototype = function() {
    * @param {String} name
    * @return The registered entry
    * @method get
+   * @memberof module:Basics.Registry.prototype
    */
   this.get = function(name) {
     var res = this.entries[name];
@@ -79,6 +86,7 @@ Registry.Prototype = function() {
    * @param {Function} callback with signature function(entry, name)
    * @param {Object} execution context
    * @method each
+   * @memberof module:Basics.Registry.prototype
    */
   this.each = function(callback, ctx) {
     for (var i = 0; i < this.names.length; i++) {

--- a/basics/uuid.js
+++ b/basics/uuid.js
@@ -13,6 +13,8 @@ Dual licensed under the MIT and GPL licenses.
  * @param {String} [prefix] if provided the UUID will be prefixed.
  * @param {Number} [len] if provided a UUID with given length will be created.
  * @return A generated uuid.
+ *
+ * @memberof module:Basics
  */
 module.exports = function(prefix, len) {
   if (prefix && prefix[prefix.length-1] !== "_") {

--- a/data/data.js
+++ b/data/data.js
@@ -10,10 +10,10 @@ var EventEmitter = Substance.EventEmitter;
  *
  * @class Data
  * @extends EventEmitter
- * @constructor
  * @param {Schema} schema
  * @param {Object} [options]
- * @module Data
+ *
+ * @memberof module:Data
  */
 function Data(schema, options) {
   EventEmitter.call(this);
@@ -36,6 +36,8 @@ Data.Prototype = function() {
    * @method get
    * @param {String|Array} path node id or path to property.
    * @return a Node instance, a value or undefined if not found.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.get = function(path) {
     if (!path) {
@@ -49,6 +51,8 @@ Data.Prototype = function() {
    *
    * @method getNodes
    * @return The internal node storage.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.getNodes = function() {
     return this.nodes;
@@ -59,6 +63,8 @@ Data.Prototype = function() {
    *
    * @method create
    * @return {Node} The created node.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.create = function(nodeData) {
     var node = this.schema.getNodeFactory().create(nodeData.type, nodeData);
@@ -87,6 +93,8 @@ Data.Prototype = function() {
    * @method delete
    * @param {String} nodeId
    * @return {Node} The deleted node.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.delete = function(nodeId) {
     var node = this.nodes[nodeId];
@@ -107,6 +115,8 @@ Data.Prototype = function() {
    * @param {Array} property path
    * @param {Object} newValue
    * @return {Node} The deleted node.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.set = function(path, newValue) {
     var node = this.get(path[0]);
@@ -120,6 +130,15 @@ Data.Prototype = function() {
     return oldValue;
   };
 
+  /**
+   * Update a property incrementally.
+   *
+   * @method update
+   * @param {Array} property path
+   * @param {Object} diff
+   *
+   * @memberof module:Data.Data.prototype
+   */
   // TODO: do we really want this incremental implementation here?
   this.update = function(path, diff) {
     var oldValue = this.nodes.get(path);
@@ -175,6 +194,8 @@ Data.Prototype = function() {
    *
    * @method toJSON
    * @return {Object} Plain content.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.toJSON = function() {
     return {
@@ -188,6 +209,8 @@ Data.Prototype = function() {
    *
    * @method contains
    * @return {Boolean} `true` if a node with id exists, `false` otherwise.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.contains = function(id) {
     return (!!this.nodes[id]);
@@ -197,6 +220,8 @@ Data.Prototype = function() {
    * Clear nodes.
    *
    * @method reset
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.reset = function() {
     this.nodes = new PathAdapter();
@@ -208,6 +233,8 @@ Data.Prototype = function() {
    * @method addIndex
    * @param {String} name
    * @param {NodeIndex} index
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.addIndex = function(name, index) {
     if (this.indexes[name]) {
@@ -224,6 +251,8 @@ Data.Prototype = function() {
    * @method getIndex
    * @param {String} name
    * @return The node index.
+   *
+   * @memberof module:Data.Data.prototype
    */
   this.getIndex = function(name) {
     return this.indexes[name];

--- a/data/incremental_data.js
+++ b/data/incremental_data.js
@@ -12,12 +12,12 @@ var TextOperation = Operator.TextOperation;
 /**
  * Incremental data storage implemention.
  *
- * @class Data.Incremental
+ * @class IncrementalData
  * @extends Data
- * @constructor
  * @param {Schema} schema
  * @param {Object} [options]
- * @module Data
+ *
+ * @memberof module:Data
  */
 var IncrementalData = function(schema, options) {
   IncrementalData.super.call(this, schema, options);
@@ -31,6 +31,8 @@ IncrementalData.Prototype = function() {
    * @method create
    * @param {Object} nodeData
    * @return The applied operation.
+   *
+   * @memberof module:Data.IncrementalData.prototype
    */
   this.create = function(nodeData) {
     var op = ObjectOperation.Create([nodeData.id], nodeData);
@@ -42,8 +44,11 @@ IncrementalData.Prototype = function() {
    * Delete a node.
    *
    * @method delete
+   * @instance
    * @param {String} nodeId
    * @return The applied operation.
+   *
+   * @memberof module:Data.IncrementalData.prototype
    */
   this.delete = function(nodeId) {
     var op = null;
@@ -71,6 +76,8 @@ IncrementalData.Prototype = function() {
    * @param {Array} path
    * @param {Object} diff
    * @return The applied operation.
+   *
+   * @memberof module:Data.IncrementalData.prototype
    */
   this.update = function(path, diff) {
     var diffOp = this._getDiffOp(path, diff);
@@ -86,6 +93,8 @@ IncrementalData.Prototype = function() {
    * @param {Array} path
    * @param {Object} newValue
    * @return The applied operation.
+   *
+   * @memberof module:Data.IncrementalData.prototype
    */
   this.set = function(path, newValue) {
     var oldValue = this.get(path);
@@ -99,6 +108,8 @@ IncrementalData.Prototype = function() {
    *
    * @method apply
    * @param {ObjectOperation} op
+   *
+   * @memberof module:Data.IncrementalData.prototype
    */
   this.apply = function(op) {
     if (op.type === ObjectOperation.NOP) return;

--- a/data/index.js
+++ b/data/index.js
@@ -7,7 +7,6 @@
  * support for OT based incremental manipulations, etc.
  *
  * @module Data
- * @main Data
  */
 
 var Data = require('./data');

--- a/data/node.js
+++ b/data/node.js
@@ -8,19 +8,15 @@ var EventEmitter = require('../basics/event_emitter');
 /**
  * Base node implemention.
  *
- * @class Data.Node
+ * @class Node
  * @extends EventEmitter
- * @constructor
  * @param {Object} properties
- * @module Data
+ *
+ * @memberof module:Data
  */
 function Node( properties ) {
   EventEmitter.call(this);
 
-  /**
-   * The internal storage for properties.
-   * @property properties {Object}
-   */
   this.properties = _.extend({}, this.getDefaultProperties(), properties);
   this.properties.type = this.constructor.static.name;
   this.properties.id = this.properties.id || uuid(this.properties.type);
@@ -34,6 +30,8 @@ Node.Prototype = function() {
    * The node's schema.
    *
    * @property properties {Object}
+   *
+   * @memberof module:Data.Node.prototype
    */
   this.properties = {
     type: 'string',
@@ -47,6 +45,8 @@ Node.Prototype = function() {
    *
    * @method toJSON
    * @return Plain object.
+   *
+   * @memberof module:Data.Node.prototype
    */
   this.toJSON = function() {
     return this.properties;
@@ -59,6 +59,8 @@ Node.Prototype = function() {
    *
    * @method getDefaultProperties
    * @return An object containing default properties.
+   *
+   * @memberof module:Data.Node.prototype
    */
   this.getDefaultProperties = function() {};
 
@@ -68,6 +70,8 @@ Node.Prototype = function() {
    * @method isInstanceOf
    * @param {String} typeName
    * @return true if the node has a parent with given type, false otherwise.
+   *
+   * @memberof module:Data.Node.prototype
    */
   this.isInstanceOf = function(typeName) {
     return Node.isInstanceOf(this.constructor, typeName);
@@ -78,6 +82,8 @@ Node.Prototype = function() {
    *
    * @method getTypeNames
    * @return An array of type names.
+   *
+   * @memberof module:Data.Node.prototype
    */
   this.getTypeNames = function() {
     var typeNames = [];
@@ -95,6 +101,8 @@ Node.Prototype = function() {
    * @method getPropertyType
    * @param {String} propertyName
    * @return The property's type.
+   *
+   * @memberof module:Data.Node.prototype
    */
   this.getPropertyType = function(propertyName) {
     var schema = this.constructor.static.schema;
@@ -109,6 +117,8 @@ OO.inherit(Node, EventEmitter);
  * Symbolic name for this model class. Must be set to a unique string by every subclass.
  * @static
  * @property name {String}
+ *
+ * @memberof module:Data.Node
  */
 Node.static.name = "node";
 
@@ -117,6 +127,8 @@ Node.static.name = "node";
  *
  * @property readOnlyProperties {Array}
  * @static
+ *
+ * @memberof module:Data.Node
  */
 // FIXME: this is not working. We can't rely on static attributes
 // for defining node properties, as they will be defined when inherited
@@ -129,6 +141,8 @@ Node.static.readOnlyProperties = ['type', 'id'];
  * @method isInstanceOf
  * @static
  * @private
+ *
+ * @memberof module:Data.Node
  */
  Node.isInstanceOf = function(NodeClass, typeName) {
   var staticData = NodeClass.static;

--- a/data/node_factory.js
+++ b/data/node_factory.js
@@ -7,10 +7,10 @@ var Factory = Substance.Factory;
 /**
  * Factory for Nodes.
  *
- * @class Data.NodeFactory
+ * @class NodeFactory
  * @extends Factory
- * @constructor
- * @module Data
+ *
+ * @memberof module:Data
  */
 function NodeFactory() {
   Factory.call(this);
@@ -22,6 +22,8 @@ NodeFactory.Prototype = function() {
    *
    * @method register
    * @param {Class} nodeClass
+   *
+   * @memberof module:Data.NodeFactory.prototype
    */
   this.register = function ( nodeClazz ) {
     var name = nodeClazz.static && nodeClazz.static.name;

--- a/data/node_index.js
+++ b/data/node_index.js
@@ -9,15 +9,18 @@ var PathAdapter = Substance.PathAdapter;
  * Node indexes are first-class citizens in Substance.Data.
  * I.e., they are updated after each operation.
  *
- * @class Data.NodeIndex
- * @constructor
- * @module Data
+ * @class NodeIndex
+ *
+ * @memberof module:Data
  */
 var NodeIndex = function() {
   /**
    * Internal storage.
+   *
    * @property {PathAdapter} index
    * @private
+   *
+   * @instance module:Data.NodeIndex
    */
   this.index = new PathAdapter();
 };
@@ -29,6 +32,8 @@ NodeIndex.Prototype = function() {
    *
    * @method reset
    * @private
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.reset = function(data) {
     this.index.clear();
@@ -48,6 +53,8 @@ NodeIndex.Prototype = function() {
    *
    * @property {String} property
    * @protected
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.property = "id";
 
@@ -58,6 +65,8 @@ NodeIndex.Prototype = function() {
    *
    * @method select
    * @protected
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.select = function(node) {
     if(!this.type) {
@@ -73,6 +82,8 @@ NodeIndex.Prototype = function() {
    * @method get
    * @param {Array} path
    * @return A node or an object with ids and nodes as values.
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   // TODO: what is the correct return value. We have arrays at some places.
   this.get = function(path) {
@@ -86,6 +97,8 @@ NodeIndex.Prototype = function() {
    *
    * @method getAll
    * @return An object with ids as keys and nodes as values.
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   // TODO: is that true?
   this.getAll = function() {
@@ -104,6 +117,8 @@ NodeIndex.Prototype = function() {
    * @method create
    * @param {Node} node
    * @protected
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.create = function(node) {
     var values = node[this.property];
@@ -123,6 +138,8 @@ NodeIndex.Prototype = function() {
    * @method delete
    * @param {Node} node
    * @protected
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.delete = function(node) {
     var values = node[this.property];
@@ -142,6 +159,8 @@ NodeIndex.Prototype = function() {
    * @method update
    * @param {Node} node
    * @protected
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.update = function(node, path, newValue, oldValue) {
     if (!this.select(node) || path[1] !== this.property) return;
@@ -166,6 +185,8 @@ NodeIndex.Prototype = function() {
    *
    * @method clone
    * @return A cloned NodeIndex.
+   *
+   * @memberof module:Data.NodeIndex.prototype
    */
   this.clone = function() {
     var NodeIndexClass = this.constructor;
@@ -183,6 +204,8 @@ Substance.initClass( NodeIndex );
  * @param {Object} prototype
  * @static
  * @return A customized NodeIndex.
+ *
+ * @memberof module:Data.NodeIndex
  */
 NodeIndex.create = function(prototype) {
   var index = Substance.extend(new NodeIndex(), prototype);

--- a/data/schema.js
+++ b/data/schema.js
@@ -9,28 +9,36 @@ var NodeFactory = require('./node_factory');
  * Data Schema.
  *
  * @class Data.Schema
- * @constructor
  * @param {String} name
  * @param {String} version
- * @module Data
+ *
+ * @memberof module:Data
  */
 function Schema(name, version) {
   /**
    * @property {String} name
+   * @memberof module:Data.Schema
+   * @instance
    */
   this.name = name;
   /**
    * @property {String} version
+   * @memberof module:Data.Schema
+   * @instance
    */
   this.version = version;
   /**
    * @property {NodeFactory} nodeFactory
    * @private
+   * @memberof module:Data.Schema
+   * @instance
    */
   this.nodeFactory = new NodeFactory();
   /**
    * @property {Array} _tocTypes all Node classes which have `Node.static.tocType = true`
    * @private
+   * @memberof module:Data.Schema
+   * @instance
    */
   this.tocTypes = [];
 
@@ -45,6 +53,8 @@ Schema.Prototype = function() {
    *
    * @method addNodes
    * @param {Array} nodes Array of Node classes
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.addNodes = function(nodes) {
     if (!nodes) return;
@@ -62,6 +72,8 @@ Schema.Prototype = function() {
    *
    * @method getNodeClass
    * @param {String} name
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.getNodeClass = function(name) {
     return this.nodeFactory.get(name);
@@ -73,6 +85,8 @@ Schema.Prototype = function() {
    * @method getNodeFactory
    * @return A NodeFactory instance.
    * @deprecated Use `this.createNode(type, data)` instead.
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.getNodeFactory = function() {
     return this.nodeFactory;
@@ -92,6 +106,8 @@ Schema.Prototype = function() {
    *
    * @method toJSON
    * @return A plain object describing the schema.
+   *
+   * @memberof module:Data.Schema.prototype
    */
   // TODO: what is this used for? IMO this is not necessary anymore
   this.toJSON = function() {
@@ -113,6 +129,8 @@ Schema.Prototype = function() {
    * @param {String} type
    * @param {Object} properties
    * @return A new Node instance.
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.createNode = function(type, properties) {
     var node = this.nodeFactory.create(type, properties);
@@ -127,6 +145,8 @@ Schema.Prototype = function() {
    * @method getBuiltIns
    * @protected
    * @return An array of Node classes.
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.getBuiltIns = function() {
     return [ Node ];
@@ -139,6 +159,8 @@ Schema.Prototype = function() {
    * @param {String} type
    * @param {String} parentType
    * @return True if type instanceof parentType.
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.isInstanceOf = function(type, parentType) {
     var NodeClass = this.getNodeClass(type);
@@ -156,6 +178,8 @@ Schema.Prototype = function() {
    * @method each
    * @param {Function} callback
    * @param {Object} context
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.each = function() {
     this.nodeFactory.each.apply(this.nodeFactory, arguments);
@@ -164,11 +188,19 @@ Schema.Prototype = function() {
   /**
    * @method getTocTypes
    * @return list of types that should appear in a TOC
+   *
+   * @memberof module:Data.Schema.prototype
    */
   this.getTocTypes = function() {
     return this.tocTypes;
   };
 
+  /**
+   * @method detDefaultTextType
+   * @return the name of the default textish node (e.g. 'paragraph')
+   *
+   * @memberof module:Data.Schema.prototype
+   */
   this.getDefaultTextType = function() {
     throw new Error('Schmema.prototype.getDefaultTextType() must be overridden.');
   };

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,7 @@
+# Substance API Documentation
+
+TODO:
+- add a narrative introduction to Subtance modules
+- jsdoc supports *Tutorials* which can be used to add additional MD files for
+  specific topics
+- there also seems to be some support for adding assets (via configuration `staticFiles`)

--- a/document/nodes/table_matrix.js
+++ b/document/nodes/table_matrix.js
@@ -254,7 +254,7 @@ TableMatrix.Prototype = function() {
   /**
    * Provides a tuple with number of rows and columns.
    *
-   * @return {Number[2]} (number of rows) X (number of columns)
+   * @return {Number} (number of rows) X (number of columns)
    */
   this.getSize = function () {
     var matrix = this.getMatrix();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "main": "index.js",
   "scripts": {
     "test": "gulp build-test && gulp test",
-    "karma": "./node_modules/.bin/karma start"
+    "karma": "./node_modules/.bin/karma start",
+    "doc": "./node_modules/.bin/jsdoc -r -c .jsdoc -d ./dist/doc ./data ./basics doc/index.md"
   },
   "author": "",
   "license": "MIT",
@@ -31,6 +32,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",
     "gulp-yuidoc": "^0.1.2",
+    "jsdoc": "^3.3.3",
     "karma": "^0.13.10",
     "karma-chrome-launcher": "^0.1.12",
     "karma-commonjs": "oliver----/karma-commonjs#patched",

--- a/ui/component.js
+++ b/ui/component.js
@@ -1368,7 +1368,7 @@ Component._render = function(data, options) {
  * and then appended to the given element.
  * If the element is in the DOM, all components receive a 'didMount' event.
  *
- * @param {Component,VirtualComponent} component to be mounted
+ * @param {Component|VirtualComponent} component to be mounted
  * @param el a DOM or jQuery element
  * @return {Component} the mounted component
  */


### PR DESCRIPTION
There are some things to be considered so that jsdoc creates the desired output:
- in every 'sub-module' (e.g. 'basics') we put a `@module` declaration into the `index.js` file: https://github.com/substance/substance/commit/1b0afa73e0334672b1ac153f744ac1b1dbab3be3#diff-23333edbbf1e9d87c7d79217bd9930d4L12
- other modules within the main modules (e.g., basics/oo) should be declared using '/', e.g. `Basics/Helpers`: https://github.com/substance/substance/commit/1b0afa73e0334672b1ac153f744ac1b1dbab3be3#diff-c3f5846a2605df71445fde36a4c5b03eR10
  There is no support for child-modules in jsdoc, so they will not show up within the main modules documentation. However we can document them as properties there: https://github.com/substance/substance/commit/1b0afa73e0334672b1ac153f744ac1b1dbab3be3#diff-c614e68c2023701920b90f24c358a3a9R18
- classes should have a `@class` annotation. To let them show-up within the modules documentation we need to bind them using `@memberof`: https://github.com/substance/substance/commit/1b0afa73e0334672b1ac153f744ac1b1dbab3be3#diff-764613c7e9e3b43466d7382faf0d4f9aR10
- class prototype functions need to be bound to the class using `@memberof`: https://github.com/substance/substance/commit/1b0afa73e0334672b1ac153f744ac1b1dbab3be3#diff-e57a1df2675e7c92dbac37fb85fc5bf3R24
- static class functions should be bound with: https://github.com/substance/substance/commit/1b0afa73e0334672b1ac153f744ac1b1dbab3be3#diff-c67a8a8345dc0f893fce1a0f0c571281R121
