### PR TITLE
Handle triple click events to fix selection behavior.

### DIFF
--- a/ui/TextPropertyComponent.js
+++ b/ui/TextPropertyComponent.js
@@ -27,6 +27,7 @@ function TextPropertyComponent() {
 
 TextPropertyComponent.Prototype = function() {
 
+
   this.initialize = function() {
     // Only register Property when inside a surface context
     if (this.getSurface()) {
@@ -47,8 +48,47 @@ TextPropertyComponent.Prototype = function() {
     };
   };
 
+  /**
+    Handles triple clicks
+
+    Inline nodes (contenteditable=false islands) lead to unexpected
+    behavior on triple click (selection gets blocked). This fix
+    ensures the expected full text property selection is made.
+
+    TODO: Do extensive cross browser testing and only apply this
+    if really needed (e.g. for Chrome)
+
+    TODO: When user clicks between the lines of a text property, no
+    mousedown event is fired, thus the selection remains in the
+    undesired state.
+
+    @private
+  */
+  this.onTripleMouseDown = function(e) {
+    if (e.detail === 3) {
+      var doc = this.getDocument();
+      var path = this.getPath();
+      var text = doc.get(path);
+
+      var sel = doc.createSelection({
+        type: 'property',
+        path:  path,
+        startOffset: 0,
+        // TODO: Is this problematic with regards to UTF8?
+        endOffset: text.length
+      });
+
+      var surface = this.context.surface;
+      surface.setSelection(sel);
+      
+      e.preventDefault();
+      e.stopPropagation();    
+    }
+  };
+
   this.render = function() {
     var el = this.super.render.call(this);
+    el.on('mousedown', this.onTripleMouseDown);
     el.removeClass('sc-annotated-text').addClass('sc-text-property');
     return el;
   };


### PR DESCRIPTION
Inline nodes (contenteditable=false islands) lead to unexpected
behavior on triple click (selection gets blocked). This fix ensures the
expected full text property selection is made.
