### PR TITLE
Support full c'n'p in FF.

### DIFF
--- a/model/HTMLExporter.js
+++ b/model/HTMLExporter.js
@@ -46,7 +46,7 @@ HTMLExporter.Prototype = function() {
         if (name === 'id' || name === 'type') {
           return;
         }
-        var prop = this.$$('div').attr('property', name);
+        var prop = converter.$$('div').attr('property', name);
         if (node.getPropertyType(name) === 'string') {
           prop.append(converter.annotatedText([node.id, name]));
         } else {

--- a/test/unit/ui/Clipboard.test.js
+++ b/test/unit/ui/Clipboard.test.js
@@ -48,9 +48,7 @@ function ClipboardEvent() {
   this.stopPropagation = function() {};
 }
 
-
-// TODO: render a fixture
-QUnit.uiTest("Copying a JSON, HTML, and plain text", function(assert) {
+QUnit.uiTest("Copying HTML, and plain text", function(assert) {
   var doc = simple();
   var surface = new StubSurface(doc, null, 'main');
   var clipboard = new Clipboard(surface);
@@ -60,19 +58,12 @@ QUnit.uiTest("Copying a JSON, HTML, and plain text", function(assert) {
   clipboard.onCopy(event);
 
   var clipboardData = event.clipboardData;
-  assert.isDefinedAndNotNull(clipboardData.data['application/substance'], "Clipboard should contain 'application/substance' data.");
   assert.isDefinedAndNotNull(clipboardData.data['text/plain'], "Clipboard should contain plain text data.");
   assert.isDefinedAndNotNull(clipboardData.data['text/html'], "Clipboard should contain HTML data.");
 
   var htmlDoc = DOMElement.parseHTML(clipboardData.data['text/html']);
   var body = htmlDoc.find('body');
   assert.isDefinedAndNotNull(body, 'The copied HTML should always be a full HTML document string, containing a body element.');
-
-  var schema = doc.getSchema();
-  var json = JSON.parse(clipboardData.data['application/substance']);
-  assert.equal(json.schema.name, schema.name, 'JSON data should contain schema name.');
-  assert.equal(json.schema.version, schema.version, 'JSON data should contain schema version.');
-  assert.ok(isArray(json.nodes),'JSON data should contain array of nodes.');
 });
 
 QUnit.uiTest("Copying a property selection", function(assert) {
@@ -97,18 +88,6 @@ QUnit.uiTest("Copying a property selection", function(assert) {
   var el = childNodes[0];
   assert.equal(el.nodeType, 'text', "HTML element should be a text node.");
   assert.equal(el.text(), TEXT, "HTML text should be correct.");
-
-  var json = JSON.parse(clipboardData.data['application/substance']);
-  var nodes = {};
-  each(json.nodes, function(node) {
-    nodes[node.id] = node;
-  });
-  assert.isDefinedAndNotNull(nodes[CLIPBOARD_CONTAINER_ID], 'JSON should contain the clipboard container node');
-  assert.isDefinedAndNotNull(nodes[CLIPBOARD_PROPERTY_ID], 'JSON should contain the clipboard property node');
-  assert.equal(nodes[CLIPBOARD_CONTAINER_ID].nodes.length, 1, "The clipboard container should contain one node.");
-  assert.equal(nodes[CLIPBOARD_CONTAINER_ID].nodes[0], CLIPBOARD_PROPERTY_ID, "... which should be the property node.");
-  assert.equal(nodes[CLIPBOARD_PROPERTY_ID].type, schema.getDefaultTextType(), "The property node should be a default text type.");
-  assert.equal(nodes[CLIPBOARD_PROPERTY_ID].content, TEXT, "The property node should be a default text type.");
 });
 
 QUnit.uiTest("Copying a container selection", function(assert) {
@@ -202,46 +181,6 @@ QUnit.uiTest("Pasting text into ContainerEditor using 'text/html'.", function(as
   event.clipboardData.setData('text/html', TEXT);
   editor.clipboard.onPaste(event);
   assert.equal(doc.get(['p1', 'content']), '0XXX123456789', "Plain text should be correct.");
-});
-
-QUnit.uiTest("Pasting text into ContainerEditor using json.", function(assert) {
-  var editor = _containerEditorSample();
-  var doc = editor.getDocument();
-  var schema = doc.getSchema();
-
-  var TEXT = 'XXX';
-  var json = {
-    schema: {
-      name: schema.name,
-      version: schema.version
-    },
-    nodes: [
-      { type: 'paragraph',  id: CLIPBOARD_PROPERTY_ID, content: TEXT},
-      { type: 'container', id: CLIPBOARD_CONTAINER_ID, nodes: [CLIPBOARD_PROPERTY_ID] }
-    ]
-  };
-  var event = new ClipboardEvent();
-  // Note: intentionally setting a different plain-text data
-  // to make sure that pasting has been done via json
-  event.clipboardData.setData('text/plain', 'ZZZ');
-  event.clipboardData.setData('application/substance', JSON.stringify(json));
-  editor.clipboard.onPaste(event);
-  assert.equal(doc.get(['p1', 'content']), '0XXX123456789', "Text should be have been inserted correctly.");
-});
-
-QUnit.uiTest("Pasting using json with wrong schema.", function(assert) {
-  var editor = _containerEditorSample();
-  var doc = editor.getDocument();
-  var json = {
-    schema: { name: 'WRONG SCHEMA', version: '1.0.0' },
-    nodes: []
-  };
-  var event = new ClipboardEvent();
-  event.clipboardData.setData('text/plain', 'XXX');
-  event.clipboardData.setData('application/substance', JSON.stringify(json));
-
-  editor.clipboard.onPaste(event);
-  assert.equal(doc.get(['p1', 'content']), '0XXX123456789', "Pasting should have fallen back to plain-text pasting.");
 });
 
 function _with(assert, fixture, fn) {

--- a/ui/ClipboardExporter.js
+++ b/ui/ClipboardExporter.js
@@ -5,6 +5,7 @@ var ClipboardImporter = require('./ClipboardImporter');
 var converters = ClipboardImporter.converters;
 var CLIPBOARD_CONTAINER_ID = ClipboardImporter.CLIPBOARD_CONTAINER_ID;
 var CLIPBOARD_PROPERTY_ID = ClipboardImporter.CLIPBOARD_PROPERTY_ID;
+var JSONConverter = require('../model/JSONConverter');
 
 /**
   Export HTML from clipboard. Used for inter-application copy'n'paste.
@@ -35,7 +36,13 @@ ClipboardExporter.Prototype = function() {
         return el.outerHTML;
       }).join('');
     }
-    return '<html><body>' + html + '</body></html>';
+    var jsonConverter = new JSONConverter();
+    var json = [
+      "<meta name='substance' content='",
+      JSON.stringify(jsonConverter.exportDocument(doc)),
+      "'>"
+    ].join('');
+    return '<html><head>' +json+ '</head><body>' + html + '</body></html>';
   };
 
   /**
@@ -43,7 +50,7 @@ ClipboardExporter.Prototype = function() {
 
     @param {Document} doc document to convert
 
-    @return {Array} array of DOM elements each represented single node 
+    @return {Array} array of DOM elements each represented single node
   */
   this.convertDocument = function(doc) {
     var content = doc.get(CLIPBOARD_CONTAINER_ID);

--- a/ui/DefaultDOMElement.js
+++ b/ui/DefaultDOMElement.js
@@ -578,7 +578,7 @@ function _parseMarkup(str, format) {
     var parser = new window.DOMParser();
     var isFullDoc;
     if (format === 'html') {
-      isFullDoc = (str.search('<html>')>=0);
+      isFullDoc = (str.search(/<\s*html/i)>=0);
       doc = parser.parseFromString(str, 'text/html');
     } else if (format === 'xml') {
       doc = parser.parseFromString(str, 'text/xml');


### PR DESCRIPTION
Now we store JSON in a meta tag within the 'text/html' clipboard
content which is the only way to pass rich content in FF.
