### PR TITLE
Fix double registration of SwitchTextTypeTool

### DIFF
--- a/packages/text/SwitchTextTypeTool.js
+++ b/packages/text/SwitchTextTypeTool.js
@@ -14,7 +14,6 @@ var SurfaceTool = require('../../ui/SurfaceTool');
 
 function SwitchTextType() {
   SurfaceTool.apply(this, arguments);
-  this.context.toolManager.registerTool(this);
 }
 
 SwitchTextType.Prototype = function() {


### PR DESCRIPTION
The base `Tool` class takes care of registering with the `ToolManager`. So we need not register again in the `SwitchTextTypeTool` class.
