### PR TITLE
[Fix #430] TableSectionHTMLConverter uses obsolete `el.tagName = ...` syntax

### DIFF
--- a/packages/table/TableSectionHTMLConverter.js
+++ b/packages/table/TableSectionHTMLConverter.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   export: function(section, el, converter) {
-    el.tagName = 't' + section.sectionType;
+    el = el.withTagName('t' + section.sectionType);
     each(section.getRows(), function(row) {
       el.append(converter.convertNode(row));
     });

--- a/packages/table/TableSectionHTMLConverter.js
+++ b/packages/table/TableSectionHTMLConverter.js
@@ -30,6 +30,10 @@ module.exports = {
     each(section.getRows(), function(row) {
       el.append(converter.convertNode(row));
     });
+
+    // Reassigning el requires us to return el.
+    // Have a look at DOMExporter.convertNode()
+    return el;
   },
 
 };


### PR DESCRIPTION
We are reassigning a function parameter. DOMExporter.convertNode
requires us to return the element.
