### PR TITLE
More modular CollabSession.

### DIFF
--- a/model/CollabSession.js
+++ b/model/CollabSession.js
@@ -6,7 +6,6 @@ var DocumentChange = require('./DocumentChange');
 var uuid = require('../util/uuid');
 var debounce = require('lodash/debounce');
 
-
 /*
   Session that is connected to a Substance Hub allowing
   collaboration in real-time.
@@ -19,7 +18,7 @@ var debounce = require('lodash/debounce');
            - resend same commit?
            - just include affected changes with the next regular commit?
 */
-function CollabSession(doc, ws, options) {
+function CollabSession(doc, options) {
   CollabSession.super.call(this, doc, options);
 
   options = options || {};
@@ -35,24 +34,72 @@ function CollabSession(doc, ws, options) {
   // TODO: Also we need to somehow store a version number (local version)
   this.doc.version = options.docVersion;
 
+  // Internal state
+  this._opened = false;
   this.nextCommit = null;
-  this.ws = ws;
-
-  this.ws.onopen = this._onConnected.bind(this);
-  this.ws.onmessage = this._onMessage.bind(this);
-
-  this._broadCastSelectionUpdateDebounced = debounce(this._broadCastSelectionUpdate, 250);
+  this._committing = false;
+  this._pendingCommit = null;
 
   // whenever a change of a new collaborator is received
   // we add a record here
   this.collaborators = {};
   this.sessionIdPool = [1,2,3,4,5,6,7,8,9,10];
-  this.start();
+
+  // Bind handlers
+  this._broadCastSelectionUpdateDebounced = debounce(this._broadCastSelectionUpdate, 250);
+
+  // this._onConnected = this._onConnected.bind(this);
+  this._onMessage = this._onMessage.bind(this);
 }
 
 CollabSession.Prototype = function() {
 
   var _super = Object.getPrototypeOf(this);
+
+  /*
+    Connect session with remote endpoint and loads the document
+
+    @param {WebSocket} ws a connected websocket.
+  */
+  this.open = function(ws) {
+
+    if (ws.readyState !== 1) { // 1 == WebSocket.OPEN
+      throw new Error('Websocket is not open yet');
+    }
+
+    // In the case of a reconnect (first remove the old handlers)
+    this.dispose();
+    this.ws = ws;
+    this.ws.addEventListener('message', this._onMessage);
+
+    var msg = ['open', this.doc.id, this.doc.version];
+    if (this.nextCommit) {
+      // This behaves like a commit
+      msg.push(this.serializeChange(this.nextCommit));
+      this._send(msg);
+      this._afterCommit(this.nextCommit);
+    } else {
+      this._send(msg);
+    }
+  };
+
+  // Needed in the case of a reconnect or explicit close
+  this.dispose = function() {
+    if (this.ws) {
+      this.ws.removeEventListener('message', this._onMessage);  
+    }
+    // Reset to original state
+    this._opened = false;
+    this.nextCommit = null;
+    this._committing = false;
+    this._pendingCommit = null;
+  };
+
+  this.close = function() {
+    // TODO: send a message to the server that we are no longer
+    // editing that document
+    this.dispose();
+  };
 
   /*
     Send local changes to the world.
@@ -66,9 +113,9 @@ CollabSession.Prototype = function() {
       this._afterCommit(this.nextCommit);
     }
   };
-
+  
   this.start = function() {
-    this._runner = setInterval(this.commit.bind(this), 500);
+    this._runner = setInterval(this.commit.bind(this), 1000);
   };
 
   this.stop = function() {
@@ -121,29 +168,10 @@ CollabSession.Prototype = function() {
   this.afterDocumentChange = function(change, info) {
     _super.afterDocumentChange.apply(this, arguments);
 
-    // Record local chagnes into nextCommit
+    // Record local changes into nextCommit
     if (!info.remote) {
       this._recordCommit(change);
     }
-  };
-
-  /*
-    As soon as we are connected we attempt to open a document
-  */
-  this._onConnected = function() {
-    console.log(this.ws.clientId, ': Opened connection. Attempting to open a doc session on the hub.');
-    // TODO: we could provide a pending change, then we can reuse
-    // the 'oncommit' behavior of the server providing rebased changes
-    // This needs to be thought through...
-    var pendingChange = null;
-    if (pendingChange) {
-      this._committing = true;
-    }
-    var msg = ['open', this.doc.id, this.doc.version];
-    if (pendingChange) {
-      msg.push(this.serializeChange(pendingChange));
-    }
-    this._send(msg);
   };
 
   /*
@@ -285,7 +313,14 @@ CollabSession.Prototype = function() {
     }
     this.doc.version = serverVersion;
     console.log(this.ws.clientId, ': Open complete. Listening for remote changes ...');
-    this.emit('connected');
+    this._opened = true;
+    this.emit('opened');
+    // Now we start to periodically push local changes to remote
+    this.start();
+  };
+
+  this.isOpen = function() {
+    return this._opened;
   };
 
   /*

--- a/ui/ContainerEditor.js
+++ b/ui/ContainerEditor.js
@@ -277,7 +277,9 @@ ContainerEditor.Prototype = function() {
   };
 
   // Create a first text element
-  this.onCreateText = function() {
+  this.onCreateText = function(e) {
+    e.preventDefault();
+    
     var newSel;
     this.transaction(function(tx) {
       var container = tx.get(this.props.containerId);

--- a/util/WebSocket.js
+++ b/util/WebSocket.js
@@ -25,6 +25,24 @@ WebSocket.Prototype = function() {
     this.messageQueue.connectClientSocket(this);
   };
 
+  /*
+    Emulating native addEventListener API
+  */
+  this.addEventListener = function(eventName, handler) {
+    if (this['on'+eventName]) {
+      // For simplicity we only support a single handler per event atm
+      console.warn('on'+eventName, ' is already set. Overriding handler.');
+    } 
+    this['on'+eventName] = handler;
+  };
+
+  /*
+    Emulating native removeEventListener API
+  */
+  this.removeEventListener = function(eventName, handler) {
+    delete this['on'+eventName];
+  };
+
   /**
     Gets called by the message queue to handle a message
   */


### PR DESCRIPTION
Does no longer require a websocket immediately. An explicit open call now connects the CollabSession to the remote endpoint.

We need to update the collabwriter example to conform the new API.

See substance/notepad for usage and how websocket reconnecting is handled: https://github.com/substance/notepad/pull/9/files
