### PR TITLE
Add label to Figure schema.

### DIFF
--- a/packages/figure/Figure.js
+++ b/packages/figure/Figure.js
@@ -33,6 +33,7 @@ DocumentNode.extend(Figure, function FigurePrototype() {
 Figure.static.name = "figure";
 
 Figure.static.defineSchema({
+  "label": "text",
   "title": "text",
   "content": "id",
   "caption": "text",


### PR DESCRIPTION
 If it's missing, the JSON export will miss it too, so when you try to reload the document in the editor, it will fail as label will be undefined here: https://github.com/substance/substance/blob/master/packages/figure/FigureComponent.js#L35

Which will then raise here, as it will try to call _isRawHTML on undefined:
https://github.com/substance/substance/blob/918878959ef88c20b2750963e20fb5750df60f13/ui/Component.js#L1174
