### PR TITLE
Don't throw an exception when global.Substance is already defined, on…

### DIFF
--- a/util/substanceGlobals.js
+++ b/util/substanceGlobals.js
@@ -7,7 +7,7 @@ var substanceGlobals = {
 };
 
 if (global.hasOwnProperty('Substance')) {
-  throw new Error('global.Substance is already defined.');
+  console.warn('global.Substance is already defined.');
 }
 global.Substance = substanceGlobals;
 


### PR DESCRIPTION
…ly log a warning.

Given that this global variable is meant for debugging purposes only, perhaps it's enough to warn the user if it's already set, as a first step.

This warning will be seen by all users who have to separate Substance app instances on a page, so perhaps the second step should be to remove globals entirely.
