### PR TITLE
Moving click target, the button target is way too small.

### DIFF
--- a/ui/Tool.js
+++ b/ui/Tool.js
@@ -43,7 +43,9 @@ Tool.Prototype = function() {
   */
   this.render = function($$) {
     var el = $$('div')
-      .addClass('se-tool');
+      .addClass('se-tool')
+      .on('click', this.onClick);
+
 
     var title = this.getTitle();
     if (title) {
@@ -72,7 +74,6 @@ Tool.Prototype = function() {
 
   this.renderButton = function($$) {
     var button = $$('button')
-      .on('click', this.onClick)
       .append(this.props.children);
 
     if (this.state.disabled) {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/238667/15009492/e5758a08-11e6-11e6-8df2-b15583934154.png)

Only if you press on the very small ~25px x ~25px target will you fire the onClick event, clicking everywhere else will just close the popup without firing the event. This is completely unexpected. Clicking anywhere in the popup should fire the event.
