### PR TITLE
Implement a more robust version of getClientBoundingRect

### DIFF
--- a/ui/Overlay.js
+++ b/ui/Overlay.js
@@ -57,20 +57,20 @@ Overlay.Prototype = function() {
 
     if (hints) {
       var contentWidth = this.el.htmlProp('offsetWidth');
-
-      // var contentHeight = overlayContent.htmlProp('clientHeight');
-      var selectionWidth = hints.rectangle.width;
+      var contentHeight = this.el.htmlProp('offsetHeight');
+      var selectionMaxWidth = hints.rectangle.width;
       var selectionHeight = hints.rectangle.height;
-      var containerWidth = hints.rectangle.left + hints.rectangle.width + hints.rectangle.right;
-      
-      this.el.css('top', hints.rectangle.top + selectionHeight);
-      var leftPos = hints.rectangle.left - contentWidth/2 + selectionWidth/2;
+
+      // By default, Overlays are aligned center/top to the selection
+      this.el.css('top', hints.rectangle.top - contentHeight);
+      var leftPos = hints.rectangle.left + selectionMaxWidth/2 - contentWidth/2;
 
       // Must not exceed left bound
       leftPos = Math.max(leftPos, 0);
 
       // Must not exceed right bound
-      leftPos = Math.min(leftPos, containerWidth - contentWidth);
+      var maxLeftPos = hints.rectangle.left + selectionMaxWidth + hints.rectangle.right - contentWidth;
+      leftPos = Math.min(leftPos, maxLeftPos);
       this.el.css('left', leftPos);
     }
   };

--- a/util/toArray.js
+++ b/util/toArray.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/*
+  Turns array-like things (e.g. Node List, ClientRect List) into an array.
+*/
+
+function toArray(list) {
+  var array = [];
+  // iterate backwards ensuring that length is an UInt32
+  for (var i = list.length >>> 0; i--;) { 
+    array[i] = list[i];
+  }
+  return array;
+}
+
+module.exports = toArray;


### PR DESCRIPTION
This attempts to fix #584. Here’s what we need for this:
- [x] Split spanning elements into multiple client rects and calculate the union bounding box from them. This is needed if, for example, a `<span>` starts in the middle of a sentence but stretches over multiple lines. In that case, `offsetLeft` will report its offset only from where the `<span>` starts.
- [x] Find the union bounding box for multiple elements relative to a common parent and calculate its left/top/bottom/right offsets.
- [ ] Add tests for various scenarios like nested scrolling containers.

**Note:** This PR also adds a `toArray` utility function that’s used for converting `ClientRectList`s into proper arrays but can be reused for any non-Array list, e.g. `NodeList`.

**Naming**: I gave the function name some more thought and I think I would be for naming it `getRelativeBoundingRect`. I haven’t renamed it yet but I’d argue that the name should reflect that the bounding box (as well as the the offsets) is _relative_ to a parent element.
