### PR TITLE
fix: table converters use setTagName() and setTagName() also copies textContent 

### DIFF
--- a/packages/table/TableCellHTMLConverter.js
+++ b/packages/table/TableCellHTMLConverter.js
@@ -30,7 +30,7 @@ module.exports = {
 
   export: function(cell, el, converter) {
     var tagName = (cell.cellType==="head" ? "th" : "td");
-    el = el.withTagName(tagName);
+    el.setTagName(tagName);
     el.append(
       converter.annotatedText([cell.id, 'content'])
     );

--- a/packages/table/TableSectionHTMLConverter.js
+++ b/packages/table/TableSectionHTMLConverter.js
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   export: function(section, el, converter) {
-    el = el.withTagName('t' + section.sectionType);
+    el.setTagName('t' + section.sectionType);
     each(section.getRows(), function(row) {
       el.append(converter.convertNode(row));
     });

--- a/ui/BrowserDOMElement.js
+++ b/ui/BrowserDOMElement.js
@@ -112,6 +112,12 @@ BrowserDOMElement.Prototype = function() {
     this.eventListeners.forEach(function(listener) {
       newEl.addEventListener(listener.eventName, listener.handler, listener.capture);
     });
+
+    var textContent = this.getTextContent();
+    if (textContent) {
+      newEl.setTextContent(textContent);
+    }
+    
     this._replaceNativeEl(newEl);
   };
 

--- a/ui/BrowserDOMElement.js
+++ b/ui/BrowserDOMElement.js
@@ -115,7 +115,10 @@ BrowserDOMElement.Prototype = function() {
 
     var textContent = this.getTextContent();
     if (textContent) {
-      newEl.setTextContent(textContent);
+      // Warning, don't replace with setTextContent()
+      // When compiled, and executed on the browser, BrowserDOMElement
+      // newEl is a native HTML node which doesn't have setTextContent()
+      newEl.textContent = textContent;
     }
     
     this._replaceNativeEl(newEl);

--- a/ui/VirtualElement.js
+++ b/ui/VirtualElement.js
@@ -114,7 +114,7 @@ VirtualHTMLElement.Prototype = function() {
 
   this.removeClass = function(className) {
     if (this.classNames) {
-      this.classNames = this.classNames.without(className);
+      this.classNames = without(this.classNames, className);
     }
     return this;
   };


### PR DESCRIPTION
- setTagName wasn't copying textContent.
- TableCellHTMLConverter and TableSectionHTMLConverter were using the older withTagName() method. This is no longer available in BrowserDOMElement

This was pull request #566, but had to reorganize my fork's branches.
