### PR TITLE
Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
   firefox: "45.0"
 node_js:
   - "4"
-  - "0.12"
-  - "0.11"
+  - "6"
 before_script:
     - 'export CHROME_BIN=chromium-browser'
     - 'export DISPLAY=:99.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+cache:
+  directories:
+    - node_modules
 addons:
   firefox: "45.0"
 node_js:


### PR DESCRIPTION
- added caching for node_modules folder
- now only testing Node 4 (LTS) + 6 (current)

Edit: the above caching is just that node_modules is recovered from last build and npm install.
As we all know npm is perfect, but still fails sometimes to update things correctly -- there is a workaround then: 
https://travis-ci.org/substance/substance/caches
Go to this page and remove the cache. 
