### PR TITLE
Streamline configurator API's.

### DIFF
--- a/packages/prose-editor/FileClientStub.js
+++ b/packages/prose-editor/FileClientStub.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var oo = require('../util/oo');
-var EventEmitter = require('../util/EventEmitter');
+var oo = require('../../util/oo');
+var EventEmitter = require('../../util/EventEmitter');
 
-var FileClientStub = function() {
-};
+var FileClientStub = function() {};
 
 FileClientStub.Prototype = function() {
 

--- a/packages/prose-editor/ProseEditorConfigurator.js
+++ b/packages/prose-editor/ProseEditorConfigurator.js
@@ -1,0 +1,50 @@
+'use strict';
+var Configurator = require('../../util/Configurator');
+var FileClientStub = require('./FileClientStub');
+var SaveHandlerStub = require('./SaveHandlerStub');
+
+/*
+  This works well for single-column apps (such as ProseEditor).
+  Write your own Configurator for apps that require more complex
+  configuration (e.g. when there are multiple surfaces involved
+  each coming with different textTypes, enabled commands etc.)
+*/
+function ProseEditorConfigurator() {
+  ProseEditorConfigurator.super.apply(this, arguments);
+
+  // Extend configuration
+  this.config.saveHandler = new SaveHandlerStub();
+  this.config.fileClient = new FileClientStub();
+  this.config.ToolbarClass = null;
+}
+
+ProseEditorConfigurator.Prototype = function() {
+
+  this.setSaveHandler = function(saveHandler) {
+    this.config.saveHandler = saveHandler;
+  };
+
+  this.setToolbarClass = function(ToolbarClass) {
+    this.config.ToolbarClass = ToolbarClass;
+  };
+
+  this.setFileClient = function(fileClient) {
+    this.config.fileClient = fileClient;
+  };
+
+  this.getFileClient = function() {
+    return this.config.fileClient;
+  };
+
+  this.getSaveHandler = function() {
+    return this.config.saveHandler;
+  };
+
+  this.getToolbarClass = function() {
+    return this.config.ToolbarClass;
+  };
+};
+
+Configurator.extend(ProseEditorConfigurator);
+
+module.exports = ProseEditorConfigurator;

--- a/packages/prose-editor/SaveHandlerStub.js
+++ b/packages/prose-editor/SaveHandlerStub.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var oo = require('../util/oo');
+var oo = require('../../util/oo');
 
 var SaveHandlerStub = function() {
 };

--- a/util/AbstractConfigurator.js
+++ b/util/AbstractConfigurator.js
@@ -8,8 +8,6 @@ var DocumentSchema = require('../model/DocumentSchema');
 var EditingBehavior = require('../model/EditingBehavior');
 var Registry = require('../util/Registry');
 var ComponentRegistry = require('../ui/ComponentRegistry');
-var FileClientStub = require('../ui/FileClientStub');
-var SaveHandlerStub = require('../ui/SaveHandlerStub');
 var path = require('path');
 
 /**
@@ -33,10 +31,7 @@ function AbstractConfigurator() {
     macros: [],
     dndHandlers: [],
     icons: {},
-    labels: {},
-    saveHandler: SaveHandlerStub,
-    fileClient: FileClientStub,
-    ToolbarClass: null
+    labels: {}
   };
 }
 
@@ -176,20 +171,9 @@ AbstractConfigurator.Prototype = function() {
     this.config.dndHandlers.push(DragAndDropHandlerClass);
   };
 
-  this.setSaveHandler = function(saveHandler) {
-    this.config.saveHandler = saveHandler;
-  };
-
-  this.setToolbarClass = function(ToolbarClass) {
-    this.config.ToolbarClass = ToolbarClass;
-  };
-
-  this.setFileClient = function(fileClient) {
-    this.config.fileClient = fileClient;
-  };
-
   this.import = function(pkg, options) {
     pkg.configure(this, options || {});
+    return this;
   };
 
   // Config Interpreter APIs
@@ -296,16 +280,6 @@ AbstractConfigurator.Prototype = function() {
     return this.converterRegistry;
   };
 
-  this.getFileClient = function() {
-    var FileClientClass = this.config.fileClient;
-    return new FileClientClass();
-  };
-
-  this.getSaveHandler = function() {
-    var SaveHandlerClass = this.config.saveHandler;
-    return new SaveHandlerClass();
-  };
-
   this.getIconProvider = function() {
     throw new Error('This method is abstract');
   };
@@ -314,10 +288,6 @@ AbstractConfigurator.Prototype = function() {
     return this.config.textTypes.map(function(t) {
       return t.spec;
     });
-  };
-
-  this.getI18nInstance = function() {
-    throw new Error('This method is abstract.');
   };
 
   this.getLabelProvider = function() {
@@ -334,10 +304,6 @@ AbstractConfigurator.Prototype = function() {
 
   this.getMacros = function() {
     return this.config.macros;
-  };
-
-  this.getToolbarClass = function() {
-    return this.config.ToolbarClass;
   };
 
   this.createDragHandlers = function() {

--- a/util/Configurator.js
+++ b/util/Configurator.js
@@ -12,7 +12,7 @@ var LabelProvider = require('../ui/DefaultLabelProvider');
   If you need app-specific API's just extend
   and configure your custom configurator.
 */
-function Configurator(firstPackage) {
+function Configurator() {
   AbstractConfigurator.call(this);
 }
 

--- a/util/Configurator.js
+++ b/util/Configurator.js
@@ -7,19 +7,13 @@ var FontAwesomeIconProvider = require('../ui/FontAwesomeIconProvider');
 var LabelProvider = require('../ui/DefaultLabelProvider');
 
 /*
-  Default Configurator for Substance editors
+  Default Configurator for most Substance apps
 
-  This works well for single-column apps (such as ProseEditor).
-  Write your own Configurator for apps that require more complex
-  configuration (e.g. when there are multiple surfaces involved
-  each coming with different textTypes, enabled commands etc.)
+  If you need app-specific API's just extend
+  and configure your custom configurator.
 */
 function Configurator(firstPackage) {
   AbstractConfigurator.call(this);
-
-  if (firstPackage) {
-    this.import(firstPackage);
-  }
 }
 
 Configurator.Prototype = function() {

--- a/util/_bundleStyles.js
+++ b/util/_bundleStyles.js
@@ -11,7 +11,7 @@ process.on('message', function(paramStr) {
   var mainPackagePath = params.configPath;
   var Configurator = require(configuratorPath);
   var MainPackage = require(mainPackagePath);
-  var configurator = new Configurator(MainPackage);
+  var configurator = new Configurator().import(MainPackage);
   var scssFiles = configurator.getStyles();
   var result = scssFiles.map(function(scssFile) {
     var relPath = String(path.relative(rootDir, scssFile)).split(path.sep).join('/');


### PR DESCRIPTION
Move ProseEditor-specific API into separate ProseEditorConfigurator. Do not import firstPackage on construction. This is too early as inherited configurators may to things on construction before the first package is imported.
