### PR TITLE
Fix deleting isolated nodes via `deleteCharacter`

### DIFF
--- a/model/transform/deleteCharacter.js
+++ b/model/transform/deleteCharacter.js
@@ -72,10 +72,16 @@ function _deleteCharacterWithNodeSelection(tx, args) {
   var container = tx.get(containerId);
   var pos, text;
   if (sel.isFull() || ( sel.isBefore() && direction === 'right') || (sel.isAfter() && direction === 'left')) {
-    return deleteNode(tx, {
+    pos = container.getPosition(nodeId);
+    deleteNode(tx, {
       nodeId: nodeId,
       containerId: containerId
     });
+    var newNode = tx.create({
+      type: tx.getSchema().getDefaultTextType(),
+      content: ""
+    });
+    container.show(newNode.id, pos);
   } else if (sel.isBefore() && direction === 'left') {
     pos = container.getPosition(nodeId);
     if (pos > 0) {

--- a/model/transform/deleteCharacter.js
+++ b/model/transform/deleteCharacter.js
@@ -82,6 +82,9 @@ function _deleteCharacterWithNodeSelection(tx, args) {
       content: ""
     });
     container.show(newNode.id, pos);
+    return {
+      selection: tx.createSelection([newNode.id, 'content'], 0)
+    };
   } else if (sel.isBefore() && direction === 'left') {
     pos = container.getPosition(nodeId);
     if (pos > 0) {


### PR DESCRIPTION
Currently, when deleting an isolated node via `deleteCharacter` (select node, press right arrow key, press backspace), various components (e.g. `SwitchTextTypeCommand`) fail because they’re trying to reference the deleted node.

This commit fixes it by inserting a new default node when the selection was a "full selection" — similar to how `deleteSelection` works.

@michael @oliver---- Is this a valid approach or does it need to be fixed somewhere else? I’m not sure I fully understand the root problem.
