### PR TITLE
Add converters to package definitions

### DIFF
--- a/packages/blockquote/BlockquotePackage.js
+++ b/packages/blockquote/BlockquotePackage.js
@@ -3,6 +3,7 @@
 var Blockquote = require('./Blockquote');
 var BlockquoteComponent = require('./BlockquoteComponent');
 var BlockquoteHTMLConverter = require('./BlockquoteHTMLConverter');
+var BlockquoteXMLConverter = require('./BlockquoteXMLConverter');
 
 module.exports = {
   name: 'blockquote',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Blockquote);
     config.addComponent(Blockquote.static.name, BlockquoteComponent);
     config.addConverter('html', BlockquoteHTMLConverter);
+    config.addConverter('xml', BlockquoteXMLConverter);
     config.addStyle(__dirname, '_blockquote.scss');
     config.addTextType({
       name: 'blockquote',

--- a/packages/blockquote/BlockquotePackage.js
+++ b/packages/blockquote/BlockquotePackage.js
@@ -3,6 +3,7 @@
 var Blockquote = require('./Blockquote');
 var BlockquoteComponent = require('./BlockquoteComponent');
 var BlockquoteHTMLConverter = require('./BlockquoteHTMLConverter');
+var BlockquoteXMLConverter = require('./BlockquoteXMLConverter');
 
 module.exports = {
   name: 'blockquote',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Blockquote);
     config.addComponent(Blockquote.type, BlockquoteComponent);
     config.addConverter('html', BlockquoteHTMLConverter);
+    config.addConverter('xml', BlockquoteXMLConverter);
     config.addStyle(__dirname, '_blockquote.scss');
     config.addTextType({
       name: 'blockquote',

--- a/packages/code/CodePackage.js
+++ b/packages/code/CodePackage.js
@@ -4,6 +4,8 @@ var Code = require('./Code');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationTool = require('../../ui/AnnotationTool');
+var CodeHTMLConverter = require('./CodeHTMLConverter');
+var CodeXMLConverter = require('./CodeXMLConverter');
 
 module.exports = {
   name: 'code',
@@ -12,6 +14,8 @@ module.exports = {
     config.addComponent('code', AnnotationComponent);
     config.addCommand('code', AnnotationCommand, { nodeType: Code.type });
     config.addTool('code', AnnotationTool);
+    config.addConverter('html', CodeHTMLConverter);
+    config.addConverter('xml', CodeXMLConverter);
     config.addIcon('code', { 'fontawesome': 'fa-code' });
     config.addStyle(__dirname, '_code.scss');
     config.addLabel('code', {

--- a/packages/code/CodePackage.js
+++ b/packages/code/CodePackage.js
@@ -1,21 +1,21 @@
 'use strict';
 
 var Code = require('./Code');
+var CodeHTMLConverter = require('./CodeHTMLConverter');
+var CodeXMLConverter = require('./CodeXMLConverter');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationTool = require('../../ui/AnnotationTool');
-var CodeHTMLConverter = require('./CodeHTMLConverter');
-var CodeXMLConverter = require('./CodeXMLConverter');
 
 module.exports = {
   name: 'code',
   configure: function(config) {
     config.addNode(Code);
+    config.addConverter('html', CodeHTMLConverter);
+    config.addConverter('xml', CodeXMLConverter);
     config.addComponent('code', AnnotationComponent);
     config.addCommand('code', AnnotationCommand, { nodeType: Code.type });
     config.addTool('code', AnnotationTool);
-    config.addConverter('html', CodeHTMLConverter);
-    config.addConverter('xml', CodeXMLConverter);
     config.addIcon('code', { 'fontawesome': 'fa-code' });
     config.addStyle(__dirname, '_code.scss');
     config.addLabel('code', {

--- a/packages/code/CodePackage.js
+++ b/packages/code/CodePackage.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var Code = require('./Code');
+var CodeHTMLConverter = require('./CodeHTMLConverter');
+var CodeXMLConverter = require('./CodeXMLConverter');
 var CodeTool = require('./CodeTool');
 var CodeCommand = require('./CodeCommand');
 
@@ -8,6 +10,8 @@ module.exports = {
   name: 'code',
   configure: function(config) {
     config.addNode(Code);
+    config.addConverter('html', CodeHTMLConverter);
+    config.addConverter('xml', CodeXMLConverter);
     config.addCommand(CodeCommand);
     config.addTool(CodeTool);
     config.addIcon('code', { 'fontawesome': 'fa-code' });

--- a/packages/codeblock/CodeblockPackage.js
+++ b/packages/codeblock/CodeblockPackage.js
@@ -3,6 +3,7 @@
 var Codeblock = require('./Codeblock');
 var CodeblockComponent = require('./CodeblockComponent');
 var CodeblockHTMLConverter = require('./CodeblockHTMLConverter');
+var CodeblockXMLConverter = require('./CodeblockXMLConverter');
 
 module.exports = {
   name: 'codeblock',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Codeblock);
     config.addComponent('codeblock', CodeblockComponent);
     config.addConverter('html', CodeblockHTMLConverter);
+    config.addConverter('xml', CodeblockXMLConverter);
     config.addTextType({
       name: 'codeblock',
       data: {type: 'codeblock'}

--- a/packages/codeblock/CodeblockPackage.js
+++ b/packages/codeblock/CodeblockPackage.js
@@ -3,6 +3,7 @@
 var Codeblock = require('./Codeblock');
 var CodeblockComponent = require('./CodeblockComponent');
 var CodeblockHTMLConverter = require('./CodeblockHTMLConverter');
+var CodeblockXMLConverter = require('./CodeblockXMLConverter');
 
 module.exports = {
   name: 'codeblock',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Codeblock);
     config.addComponent(Codeblock.static.name, CodeblockComponent);
     config.addConverter('html', CodeblockHTMLConverter);
+    config.addConverter('xml', CodeblockXMLConverter);
     config.addTextType({
       name: 'codeblock',
       data: {type: 'codeblock'}

--- a/packages/emphasis/EmphasisPackage.js
+++ b/packages/emphasis/EmphasisPackage.js
@@ -1,23 +1,22 @@
 'use strict';
 
 var Emphasis = require('./Emphasis');
+var EmphasisHTMLConverter = require('./EmphasisHTMLConverter');
+var EmphasisXMLConverter = require('./EmphasisXMLConverter');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
-var EmphasisHTMLConverter = require('./EmphasisHTMLConverter');
-var EmphasisXMLConverter = require('./EmphasisXMLConverter');
 
 module.exports = {
   name: 'emphasis',
   configure: function(config) {
     config.addNode(Emphasis);
+    config.addConverter('html', EmphasisHTMLConverter);
+    config.addConverter('xml', EmphasisXMLConverter);
     config.addComponent('emphasis', AnnotationComponent);
     config.addCommand('emphasis', AnnotationCommand, { nodeType: Emphasis.type });
     config.addTool('emphasis', AnnotationTool);
-    config.addConverter('html', EmphasisHTMLConverter);
-    config.addConverter('xml', EmphasisXMLConverter);
     config.addStyle(__dirname, '_emphasis.scss');
-
     config.addIcon('emphasis', { 'fontawesome': 'fa-italic' });
     config.addLabel('emphasis', {
       en: 'Emphasis',

--- a/packages/heading/HeadingPackage.js
+++ b/packages/heading/HeadingPackage.js
@@ -3,6 +3,7 @@
 var Heading = require('./Heading');
 var HeadingComponent = require('./HeadingComponent');
 var HeadingHTMLConverter = require('./HeadingHTMLConverter');
+var HeadingXMLConverter = require('./HeadingXMLConverter');
 
 module.exports = {
   name: 'heading',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Heading);
     config.addComponent(Heading.static.name, HeadingComponent);
     config.addConverter('html', HeadingHTMLConverter);
+    config.addConverter('xml', HeadingXMLConverter);
     config.addTextType({
       name: 'heading1',
       data: {type: 'heading', level: 1}

--- a/packages/heading/HeadingPackage.js
+++ b/packages/heading/HeadingPackage.js
@@ -3,6 +3,7 @@
 var Heading = require('./Heading');
 var HeadingComponent = require('./HeadingComponent');
 var HeadingHTMLConverter = require('./HeadingHTMLConverter');
+var HeadingXMLConverter = require('./HeadingXMLConverter');
 
 module.exports = {
   name: 'heading',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Heading);
     config.addComponent(Heading.type, HeadingComponent);
     config.addConverter('html', HeadingHTMLConverter);
+    config.addConverter('xml', HeadingXMLConverter);
     config.addTextType({
       name: 'heading1',
       data: {type: 'heading', level: 1}

--- a/packages/image/ImagePackage.js
+++ b/packages/image/ImagePackage.js
@@ -13,11 +13,11 @@ module.exports = {
   configure: function(config) {
     config.addNode(ImageNode);
     config.addComponent('image', ImageComponent);
+    config.addConverter('html', ImageHTMLConverter);
+    config.addConverter('xml', ImageXMLConverter);
     config.addCommand('insert-image', InsertImageCommand);
     config.addTool('insert-image', InsertImageTool);
     config.addIcon('insert-image', { 'fontawesome': 'fa-image' });
-    config.addConverter('html', ImageHTMLConverter);
-    config.addConverter('xml', ImageXMLConverter);
     config.addStyle(__dirname, '_image.scss');
     config.addLabel('image', {
       en: 'Image',

--- a/packages/image/ImagePackage.js
+++ b/packages/image/ImagePackage.js
@@ -2,6 +2,8 @@
 
 var ImageNode = require('./Image');
 var ImageComponent = require('./ImageComponent');
+var ImageHTMLConverter = require('./ImageHTMLConverter');
+var ImageXMLConverter = require('./ImageXMLConverter');
 var InsertImageCommand = require('./InsertImageCommand');
 var InsertImageTool = require('./InsertImageTool');
 var DropImage = require('./DropImage');
@@ -14,11 +16,13 @@ module.exports = {
     config.addCommand('insert-image', InsertImageCommand);
     config.addTool('insert-image', InsertImageTool);
     config.addIcon('insert-image', { 'fontawesome': 'fa-image' });
+    config.addConverter('html', ImageHTMLConverter);
+    config.addConverter('xml', ImageXMLConverter);
+    config.addStyle(__dirname, '_image.scss');
     config.addLabel('image', {
       en: 'Image',
       de: 'Bild'
     });
-    config.addStyle(__dirname, '_image.scss');
     config.addLabel('insert-image', {
       en: 'Insert image',
       de: 'Bild einfügen'

--- a/packages/image/ImagePackage.js
+++ b/packages/image/ImagePackage.js
@@ -2,6 +2,8 @@
 
 var ImageNode = require('./Image');
 var ImageComponent = require('./ImageComponent');
+var ImageHTMLConverter = require('./ImageHTMLConverter');
+var ImageXMLConverter = require('./ImageXMLConverter');
 var InsertImageCommand = require('./InsertImageCommand');
 var InsertImageTool = require('./InsertImageTool');
 var DropImage = require('./DropImage');
@@ -11,6 +13,8 @@ module.exports = {
   configure: function(config) {
     config.addNode(ImageNode);
     config.addComponent(ImageNode.static.name, ImageComponent);
+    config.addConverter('html', ImageHTMLConverter);
+    config.addConverter('xml', ImageXMLConverter);
     config.addCommand(InsertImageCommand);
     config.addTool(InsertImageTool);
     config.addIcon(InsertImageCommand.static.name, { 'fontawesome': 'fa-image' });

--- a/packages/link/LinkPackage.js
+++ b/packages/link/LinkPackage.js
@@ -4,6 +4,7 @@ var Link = require('./Link');
 var LinkComponent = require('./LinkComponent');
 var LinkCommand = require('./LinkCommand');
 var LinkHTMLConverter = require('./LinkHTMLConverter');
+var LinkXMLConverter = require('./LinkXMLConverter');
 var LinkTool = require('./LinkTool');
 var EditLinkTool = require('./EditLinkTool');
 
@@ -13,6 +14,7 @@ module.exports = {
     config.addNode(Link);
     config.addComponent(Link.static.name, LinkComponent);
     config.addConverter('html', LinkHTMLConverter);
+    config.addConverter('xml', LinkXMLConverter);
     config.addCommand(LinkCommand);
     config.addTool(LinkTool);
     config.addTool(EditLinkTool, { overlay: true });

--- a/packages/link/LinkPackage.js
+++ b/packages/link/LinkPackage.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var AnnotationTool = require('../../ui/AnnotationTool');
 var Link = require('./Link');
 var LinkComponent = require('./LinkComponent');
 var LinkCommand = require('./LinkCommand');
 var LinkHTMLConverter = require('./LinkHTMLConverter');
 var LinkXMLConverter = require('./LinkXMLConverter');
+var AnnotationTool = require('../../ui/AnnotationTool');
 var EditLinkTool = require('./EditLinkTool');
 
 module.exports = {
@@ -13,11 +13,11 @@ module.exports = {
   configure: function(config) {
     config.addNode(Link);
     config.addComponent('link', LinkComponent);
+    config.addConverter('html', LinkHTMLConverter);
+    config.addConverter('xml', LinkXMLConverter);
     config.addCommand('link', LinkCommand, {nodeType: 'link'});
     config.addTool('link', AnnotationTool);
     config.addTool('edit-link', EditLinkTool, { overlay: true });
-    config.addConverter('html', LinkHTMLConverter);
-    config.addConverter('xml', LinkXMLConverter);
     config.addStyle(__dirname, '_link.scss');
     config.addIcon('link', { 'fontawesome': 'fa-link'});
     config.addIcon('open-link', { 'fontawesome': 'fa-external-link' });

--- a/packages/link/LinkPackage.js
+++ b/packages/link/LinkPackage.js
@@ -5,6 +5,7 @@ var Link = require('./Link');
 var LinkComponent = require('./LinkComponent');
 var LinkCommand = require('./LinkCommand');
 var LinkHTMLConverter = require('./LinkHTMLConverter');
+var LinkXMLConverter = require('./LinkXMLConverter');
 var EditLinkTool = require('./EditLinkTool');
 
 module.exports = {
@@ -16,6 +17,7 @@ module.exports = {
     config.addTool('link', AnnotationTool);
     config.addTool('edit-link', EditLinkTool, { overlay: true });
     config.addConverter('html', LinkHTMLConverter);
+    config.addConverter('xml', LinkXMLConverter);
     config.addStyle(__dirname, '_link.scss');
     config.addIcon('link', { 'fontawesome': 'fa-link'});
     config.addIcon('open-link', { 'fontawesome': 'fa-external-link' });

--- a/packages/paragraph/ParagraphPackage.js
+++ b/packages/paragraph/ParagraphPackage.js
@@ -3,6 +3,7 @@
 var Paragraph = require('./Paragraph');
 var ParagraphComponent = require('./ParagraphComponent');
 var ParagraphHTMLConverter = require('./ParagraphHTMLConverter');
+var ParagraphXMLConverter = require('./ParagraphXMLConverter');
 
 module.exports = {
   name: 'paragraph',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Paragraph);
     config.addComponent(Paragraph.type, ParagraphComponent);
     config.addConverter('html', ParagraphHTMLConverter);
+    config.addConverter('xml', ParagraphXMLConverter);
     config.addTextType({
       name: 'paragraph',
       data: {type: 'paragraph'}

--- a/packages/paragraph/ParagraphPackage.js
+++ b/packages/paragraph/ParagraphPackage.js
@@ -3,6 +3,7 @@
 var Paragraph = require('./Paragraph');
 var ParagraphComponent = require('./ParagraphComponent');
 var ParagraphHTMLConverter = require('./ParagraphHTMLConverter');
+var ParagraphXMLConverter = require('./ParagraphXMLConverter');
 
 module.exports = {
   name: 'paragraph',
@@ -10,6 +11,7 @@ module.exports = {
     config.addNode(Paragraph);
     config.addComponent(Paragraph.static.name, ParagraphComponent);
     config.addConverter('html', ParagraphHTMLConverter);
+    config.addConverter('xml', ParagraphXMLConverter);
     config.addTextType({
       name: 'paragraph',
       data: {type: 'paragraph'}

--- a/packages/strong/StrongPackage.js
+++ b/packages/strong/StrongPackage.js
@@ -4,6 +4,8 @@ var Strong = require('./Strong');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
+var StrongHTMLConverter = require('./StrongHTMLConverter');
+var StrongXMLConverter = require('./StrongXMLConverter');
 
 module.exports = {
   name: 'strong',
@@ -13,6 +15,8 @@ module.exports = {
     config.addCommand('strong', AnnotationCommand, { nodeType: 'strong' });
     config.addTool('strong', AnnotationTool);
     config.addIcon('strong', { 'fontawesome': 'fa-bold' });
+    config.addConverter('html', StrongHTMLConverter);
+    config.addConverter('xml', StrongXMLConverter);
     config.addStyle(__dirname, '_strong.scss');
     config.addLabel('strong', {
       en: 'Strong emphasis',

--- a/packages/strong/StrongPackage.js
+++ b/packages/strong/StrongPackage.js
@@ -1,22 +1,22 @@
 'use strict';
 
 var Strong = require('./Strong');
+var StrongHTMLConverter = require('./StrongHTMLConverter');
+var StrongXMLConverter = require('./StrongXMLConverter');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
-var StrongHTMLConverter = require('./StrongHTMLConverter');
-var StrongXMLConverter = require('./StrongXMLConverter');
 
 module.exports = {
   name: 'strong',
   configure: function(config) {
     config.addNode(Strong);
+    config.addConverter('html', StrongHTMLConverter);
+    config.addConverter('xml', StrongXMLConverter);
     config.addComponent('strong', AnnotationComponent);
     config.addCommand('strong', AnnotationCommand, { nodeType: 'strong' });
     config.addTool('strong', AnnotationTool);
     config.addIcon('strong', { 'fontawesome': 'fa-bold' });
-    config.addConverter('html', StrongHTMLConverter);
-    config.addConverter('xml', StrongXMLConverter);
     config.addStyle(__dirname, '_strong.scss');
     config.addLabel('strong', {
       en: 'Strong emphasis',

--- a/packages/strong/StrongPackage.js
+++ b/packages/strong/StrongPackage.js
@@ -3,11 +3,15 @@
 var Strong = require('./Strong');
 var StrongTool = require('./StrongTool');
 var StrongCommand = require('./StrongCommand');
+var StrongHTMLConverter = require('./StrongHTMLConverter');
+var StrongXMLConverter = require('./StrongXMLConverter');
 
 module.exports = {
   name: 'strong',
   configure: function(config) {
     config.addNode(Strong);
+    config.addConverter('html', StrongHTMLConverter);
+    config.addConverter('xml', StrongXMLConverter);
     config.addCommand(StrongCommand);
     config.addTool(StrongTool);
     config.addIcon(StrongCommand.static.name, { 'fontawesome': 'fa-bold' });

--- a/packages/subscript/SubscriptPackage.js
+++ b/packages/subscript/SubscriptPackage.js
@@ -1,22 +1,22 @@
 'use strict';
 
 var Subscript = require('./Subscript');
+var SubscriptHTMLConverter = require('./SubscriptHTMLConverter');
+var SubscriptXMLConverter = require('./SubscriptXMLConverter');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
-var SubscriptHTMLConverter = require('./SubscriptHTMLConverter');
-var SubscriptXMLConverter = require('./SubscriptXMLConverter');
 
 module.exports = {
   name: 'subscript',
   configure: function(config) {
     config.addNode(Subscript);
+    config.addConverter('html', SubscriptHTMLConverter);
+    config.addConverter('xml', SubscriptXMLConverter);
     config.addComponent('subscript', AnnotationComponent);
     config.addCommand('Subscript', AnnotationCommand, { nodeType: 'subscript' });
     config.addTool('subscript', AnnotationTool);
     config.addIcon('subscript', { 'fontawesome': 'fa-subscript' });
-    config.addConverter('html', SubscriptHTMLConverter);
-    config.addConverter('xml', SubscriptXMLConverter);
     config.addStyle(__dirname, '_subscript.scss');
     config.addLabel('subscript', {
       en: 'Subscript',

--- a/packages/subscript/SubscriptPackage.js
+++ b/packages/subscript/SubscriptPackage.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var Subscript = require('./Subscript');
+var SubscriptHTMLConverter = require('./SubscriptHTMLConverter');
+var SubscriptXMLConverter = require('./SubscriptXMLConverter');
 var SubscriptTool = require('./SubscriptTool');
 var SubscriptCommand = require('./SubscriptCommand');
 
@@ -8,6 +10,8 @@ module.exports = {
   name: 'subscript',
   configure: function(config) {
     config.addNode(Subscript);
+    config.addConverter('html', SubscriptHTMLConverter);
+    config.addConverter('xml', SubscriptXMLConverter);
     config.addCommand(SubscriptCommand);
     config.addTool(SubscriptTool);
     config.addIcon(SubscriptCommand.static.name, { 'fontawesome': 'fa-subscript' });

--- a/packages/subscript/SubscriptPackage.js
+++ b/packages/subscript/SubscriptPackage.js
@@ -4,6 +4,8 @@ var Subscript = require('./Subscript');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
+var SubscriptHTMLConverter = require('./SubscriptHTMLConverter');
+var SubscriptXMLConverter = require('./SubscriptXMLConverter');
 
 module.exports = {
   name: 'subscript',
@@ -13,6 +15,8 @@ module.exports = {
     config.addCommand('Subscript', AnnotationCommand, { nodeType: 'subscript' });
     config.addTool('subscript', AnnotationTool);
     config.addIcon('subscript', { 'fontawesome': 'fa-subscript' });
+    config.addConverter('html', SubscriptHTMLConverter);
+    config.addConverter('xml', SubscriptXMLConverter);
     config.addStyle(__dirname, '_subscript.scss');
     config.addLabel('subscript', {
       en: 'Subscript',

--- a/packages/subscript/SubscriptPackage.js
+++ b/packages/subscript/SubscriptPackage.js
@@ -14,7 +14,7 @@ module.exports = {
     config.addConverter('html', SubscriptHTMLConverter);
     config.addConverter('xml', SubscriptXMLConverter);
     config.addComponent('subscript', AnnotationComponent);
-    config.addCommand('Subscript', AnnotationCommand, { nodeType: 'subscript' });
+    config.addCommand('subscript', AnnotationCommand, { nodeType: 'subscript' });
     config.addTool('subscript', AnnotationTool);
     config.addIcon('subscript', { 'fontawesome': 'fa-subscript' });
     config.addStyle(__dirname, '_subscript.scss');

--- a/packages/superscript/SuperscriptHTMLConverter.js
+++ b/packages/superscript/SuperscriptHTMLConverter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /*
- * HTML converter for Blockquote.
+ * HTML converter for Superscript.
  */
 module.exports = {
   type: 'superscript',

--- a/packages/superscript/SuperscriptPackage.js
+++ b/packages/superscript/SuperscriptPackage.js
@@ -1,22 +1,21 @@
 'use strict';
 
 var Superscript = require('./Superscript');
+var SuperscriptHTMLConverter = require('./SuperscriptHTMLConverter');
+var SuperscriptXMLConverter = require('./SuperscriptXMLConverter');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
-var SuperscriptHTMLConverter = require('./SuperscriptHTMLConverter');
-var SuperscriptXMLConverter = require('./SuperscriptXMLConverter');
-
 
 module.exports = {
   name: 'superscript',
   configure: function(config) {
     config.addNode(Superscript);
+    config.addConverter('html', SuperscriptHTMLConverter);
+    config.addConverter('xml', SuperscriptXMLConverter);
     config.addComponent('superscript', AnnotationComponent);
     config.addCommand('superscript', AnnotationCommand, { nodeType: 'superscript' });
     config.addTool('superscript', AnnotationTool);
-    config.addConverter('html', SuperscriptHTMLConverter);
-    config.addConverter('xml', SuperscriptXMLConverter);
     config.addStyle(__dirname, '_superscript.scss');
     config.addIcon('superscript', { 'fontawesome': 'fa-superscript' });
     config.addLabel('superscript', {

--- a/packages/superscript/SuperscriptPackage.js
+++ b/packages/superscript/SuperscriptPackage.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var Superscript = require('./Superscript');
+var SuperscriptHTMLConverter = require('./SuperscriptHTMLConverter');
+var SuperscriptXMLConverter = require('./SuperscriptXMLConverter');
 var SuperscriptTool = require('./SuperscriptTool');
 var SuperscriptCommand = require('./SuperscriptCommand');
 
@@ -8,6 +10,8 @@ module.exports = {
   name: 'superscript',
   configure: function(config) {
     config.addNode(Superscript);
+    config.addConverter('html', SuperscriptHTMLConverter);
+    config.addConverter('xml', SuperscriptXMLConverter);
     config.addCommand(SuperscriptCommand);
     config.addTool(SuperscriptTool);
     config.addStyle(__dirname, '_superscript.scss');

--- a/packages/superscript/SuperscriptPackage.js
+++ b/packages/superscript/SuperscriptPackage.js
@@ -4,6 +4,9 @@ var Superscript = require('./Superscript');
 var AnnotationCommand = require('../../ui/AnnotationCommand');
 var AnnotationComponent = require('../../ui/AnnotationComponent');
 var AnnotationTool = require('../../ui/AnnotationTool');
+var SuperscriptHTMLConverter = require('./SuperscriptHTMLConverter');
+var SuperscriptXMLConverter = require('./SuperscriptXMLConverter');
+
 
 module.exports = {
   name: 'superscript',
@@ -12,6 +15,8 @@ module.exports = {
     config.addComponent('superscript', AnnotationComponent);
     config.addCommand('superscript', AnnotationCommand, { nodeType: 'superscript' });
     config.addTool('superscript', AnnotationTool);
+    config.addConverter('html', SuperscriptHTMLConverter);
+    config.addConverter('xml', SuperscriptXMLConverter);
     config.addStyle(__dirname, '_superscript.scss');
     config.addIcon('superscript', { 'fontawesome': 'fa-superscript' });
     config.addLabel('superscript', {

--- a/packages/superscript/SuperscriptXMLConverter.js
+++ b/packages/superscript/SuperscriptXMLConverter.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = require('./SubscriptHTMLConverter');
+module.exports = require('./SuperscriptHTMLConverter');

--- a/packages/table/InsertTableCommand.js
+++ b/packages/table/InsertTableCommand.js
@@ -4,7 +4,7 @@ var InsertNodeCommand = require('../../ui/InsertNodeCommand');
 var uuid = require('../../util/uuid');
 
 function InsertTableCommand() {
-  InsertTableCommand.super.apply(this, { name: 'insert-table' });
+  InsertTableCommand.super.call(this, { name: 'insert-table' });
 }
 
 InsertTableCommand.Prototype = function() {


### PR DESCRIPTION
A few converters where missing from package definitions. This meant that a `HTMLImporter` using a converter list from a configurator e.g. `configurator.getConverterRegistry().get('html')` would fail to import a document properly. Adds XML as well as missing HTML importers and fixes `SuperscriptXMLConverter`
