### PR TITLE
Add editor to command context

### DIFF
--- a/ui/AbstractEditor.js
+++ b/ui/AbstractEditor.js
@@ -91,6 +91,7 @@ AbstractEditor.Prototype = function() {
 
   this.getCommandContext = function() {
     return {
+      editor: this,
       documentSession: this.documentSession,
       surfaceManager: this.surfaceManager,
       fileClient: this.fileClient,


### PR DESCRIPTION
I have a couple of `Commands` which alter the `state` of the document editor, rather than the document itself (for switch editing modes). I wrote a base command class for that whose `execute` method needs to be able to access the editor:

``` js
  this.execute = function(props, context) {
    // Toggle active switch
    this.active = !this.active;
    // Since this command does not trigger a document update
    // we need to trigger an update to command states BEFORE
    // extending the state of, and thus rerending, the editor
    context.editor.commandManager.updateCommandStates();
    // Update the editor state
    var state = {};
    state[this.getStateName()] = this.active;
    context.editor.extendState(state);
    return true;
  }
```

The best way I could see to do that was to add the editor to the command context - hence the single line commit in this PR. But please let me know if there is a better approach.
