### PR TITLE
Notes fixes

### DIFF
--- a/collab/CollabServer.js
+++ b/collab/CollabServer.js
@@ -173,6 +173,7 @@ CollabServer.Prototype = function() {
     collaborators[collaboratorId] = null;
 
     this.broadCast(collaboratorIds, {
+      scope: this.scope,
       type: 'update',
       documentId: documentId,
       // Removes the entry

--- a/collab/CollabSession.js
+++ b/collab/CollabSession.js
@@ -43,7 +43,7 @@ function CollabSession(doc, config) {
     throw new Err('InvalidArgumentsError', {message: 'documentId is mandatory'});
   }
 
-  if (typeof this.version === 'undefined') {
+  if (typeof this.version === undefined) {
     throw new Err('InvalidArgumentsError', {message: 'version is mandatory'});
   }
 

--- a/collab/CollabSession.js
+++ b/collab/CollabSession.js
@@ -250,6 +250,7 @@ CollabSession.Prototype = function() {
       var collaboratorsChange = this._updateCollaborators(collaborators);
       if (collaboratorsChange) {
         update.collaborators = collaboratorsChange;
+        this.emit('collaborators:changed');
       }
       this._triggerUpdateEvent(update, { remote: true });
     } else {

--- a/collab/CollabSession.js
+++ b/collab/CollabSession.js
@@ -30,7 +30,7 @@ function CollabSession(doc, config) {
     console.warn('config.docId is deprecated: Use config.documentId instead');
   }
 
-  this.version = config.version || config.docVersion;
+  this.version = config.version;
   this.documentId = config.documentId || config.docId;
 
   if (config.autoSync !== undefined) {
@@ -43,7 +43,7 @@ function CollabSession(doc, config) {
     throw new Err('InvalidArgumentsError', {message: 'documentId is mandatory'});
   }
 
-  if (!this.version) {
+  if (typeof this.version === 'undefined') {
     throw new Err('InvalidArgumentsError', {message: 'version is mandatory'});
   }
 

--- a/collab/DocumentEngine.js
+++ b/collab/DocumentEngine.js
@@ -164,7 +164,7 @@ DocumentEngine.Prototype = function() {
           info: args.documentInfo
         }, function(err) {
           if (err) return cb(err);
-          this.snapshotEngine.requestSnapshot(args.documentId, function() {
+          this.snapshotEngine.requestSnapshot(args.documentId, newVersion, function() {
             // no matter if errored or not we will complete the addChange
             // successfully
             cb(null, newVersion);

--- a/collab/SnapshotEngine.js
+++ b/collab/SnapshotEngine.js
@@ -10,7 +10,7 @@ var Err = require('../util/SubstanceError');
   API for creating and retrieving snapshots of documents
 */
 function SnapshotEngine(config) {
-  this.schemas = config.schemas;
+  this.configurator = config.configurator;
   this.changeStore = config.changeStore;
   this.documentStore = config.documentStore;
 
@@ -182,15 +182,14 @@ SnapshotEngine.Prototype = function() {
     on given schema configuration
   */
   this._createDocumentInstance = function(schemaName) {
-    var schemaConfig = this.schemas[schemaName];
+    var schema = this.configurator.getSchema();
 
-    if (!schemaConfig) {
+    if (schema.name !== schemaName) {
       throw new Err('SnapshotEngine.SchemaNotFoundError', {
         message:'Schema ' + schemaName + ' not found'
       });
     }
-
-    var doc = schemaConfig.documentFactory.createDocument();
+    var doc = this.configurator.createArticle();
     return doc;
   };
 

--- a/test/collab/CollabEngine.test.js
+++ b/test/collab/CollabEngine.test.js
@@ -6,12 +6,12 @@ var ChangeStore = require('../../collab/ChangeStore');
 var DocumentEngine = require('../../collab/DocumentEngine');
 var CollabEngine = require('../../collab/CollabEngine');
 
-var createTestDocumentFactory = require('../fixtures/createTestDocumentFactory');
+// var createTestDocumentFactory = require('../fixtures/createTestDocumentFactory');
 // var createTestArticle = require('../fixtures/createTestArticle');
 // var createChangeset = require('../fixtures/createChangeset');
 var documentStoreSeed = require('../fixtures/documentStoreSeed');
 var changeStoreSeed = require('../fixtures/changeStoreSeed');
-var twoParagraphs = require('../fixtures/twoParagraphs');
+// var twoParagraphs = require('../fixtures/twoParagraphs');
 // var insertParagraph = require('../fixtures/insertParagraph');
 // var insertText = require('../fixtures/insertText');
 
@@ -29,14 +29,7 @@ var changeStore = new ChangeStore();
 
 var documentEngine = new DocumentEngine({
   documentStore: documentStore,
-  changeStore: changeStore,
-  schemas: {
-    'prose-article': {
-      name: 'prose-article',
-      version: '1.0.0',
-      documentFactory: createTestDocumentFactory(twoParagraphs)
-    }
-  }
+  changeStore: changeStore
 });
 
 var fakeChange = {

--- a/test/collab/SnapshotEngine.test.js
+++ b/test/collab/SnapshotEngine.test.js
@@ -8,6 +8,10 @@ var SnapshotStore = require('../../collab/SnapshotStore');
 var ChangeStore = require('../../collab/ChangeStore');
 var SnapshotEngine = require('../../collab/SnapshotEngine');
 
+var Configurator = require('../../util/Configurator');
+var TestArticle = require('../model/TestArticle');
+var TestMetaNode = require('../model/TestMetaNode');
+ 
 var testSnapshotEngine = require('./testSnapshotEngine');
 var testSnapshotEngineWithStore = require('./testSnapshotEngineWithStore');
 var createTestDocumentFactory = require('../fixtures/createTestDocumentFactory');
@@ -17,32 +21,29 @@ var changeStoreSeed = require('../fixtures/changeStoreSeed');
 var snapshotStoreSeed = require('../fixtures/snapshotStoreSeed');
 
 // Setup store instances
+
+var configurator = new Configurator();
+configurator.defineSchema({
+  name: 'prose-article',
+  ArticleClass: TestArticle,
+  defaultTextType: 'paragraph'
+});
+configurator.addNode(TestMetaNode);
+
 var documentFactory = createTestDocumentFactory(twoParagraphs);
 var documentStore = new DocumentStore();
 var changeStore = new ChangeStore();
 var snapshotEngine = new SnapshotEngine({
+  configurator: configurator,
   documentStore: documentStore,
   changeStore: changeStore,
-  schemas: {
-    'prose-article': {
-      name: 'prose-article',
-      version: '1.0.0',
-      documentFactory: documentFactory
-    }
-  }
 });
 var snapshotStore = new SnapshotStore();
 var snapshotEngineWithStore = new SnapshotEngine({
+  configurator: configurator,
   documentStore: documentStore,
   changeStore: changeStore,
-  snapshotStore: snapshotStore,
-  schemas: {
-    'prose-article': {
-      name: 'prose-article',
-      version: '1.0.0',
-      documentFactory: documentFactory
-    }
-  }
+  snapshotStore: snapshotStore
 });
 
 function setup(cb, t) {

--- a/test/collab/SnapshotEngine.test.js
+++ b/test/collab/SnapshotEngine.test.js
@@ -14,8 +14,6 @@ var TestMetaNode = require('../model/TestMetaNode');
  
 var testSnapshotEngine = require('./testSnapshotEngine');
 var testSnapshotEngineWithStore = require('./testSnapshotEngineWithStore');
-var createTestDocumentFactory = require('../fixtures/createTestDocumentFactory');
-var twoParagraphs = require('../fixtures/twoParagraphs');
 var documentStoreSeed = require('../fixtures/documentStoreSeed');
 var changeStoreSeed = require('../fixtures/changeStoreSeed');
 var snapshotStoreSeed = require('../fixtures/snapshotStoreSeed');
@@ -30,7 +28,6 @@ configurator.defineSchema({
 });
 configurator.addNode(TestMetaNode);
 
-var documentFactory = createTestDocumentFactory(twoParagraphs);
 var documentStore = new DocumentStore();
 var changeStore = new ChangeStore();
 var snapshotEngine = new SnapshotEngine({
@@ -72,9 +69,9 @@ function setupTest(description, fn) {
 }
 
 // Run the generic testsuite with an engine that does not have a store attached
-testSnapshotEngine(snapshotEngine, documentFactory, setupTest);
+testSnapshotEngine(snapshotEngine, setupTest);
 // Run the same testsuite but this time with a store
-testSnapshotEngine(snapshotEngineWithStore, documentFactory, setupTest);
+testSnapshotEngine(snapshotEngineWithStore, setupTest);
 
 // Run tests that are only relevant when a snapshot store is provided to the engine
-testSnapshotEngineWithStore(snapshotEngineWithStore, documentFactory, setupTest);
+testSnapshotEngineWithStore(snapshotEngineWithStore, setupTest);

--- a/test/collab/testSnapshotEngine.js
+++ b/test/collab/testSnapshotEngine.js
@@ -1,7 +1,7 @@
 'use strict';
 // Please see snapshotStoreSeed.js for the used fixture data
 
-function testSnapshotEngine(snapshotEngine, docFactory, test) {
+function testSnapshotEngine(snapshotEngine, test) {
   test('Compute a new snapshot', function(t) {
     snapshotEngine.getSnapshot({documentId: 'test-doc'}, function(err, snapshot) {
       t.notOk(err, 'There should be no error');

--- a/test/collab/testSnapshotEngineWithStore.js
+++ b/test/collab/testSnapshotEngineWithStore.js
@@ -2,7 +2,7 @@
 
 // Please see snapshotStoreSeed.js for the used fixture data
 
-function testSnapshotEngineWithPersistence(snapshotEngine, docFactory, test) {
+function testSnapshotEngineWithPersistence(snapshotEngine, test) {
   test('Compute a new snapshot', function(t) {
     snapshotEngine.getSnapshot({documentId: 'test-doc'}, function(err, snapshot) {
       t.notOk(err, 'There should be no error');

--- a/test/model/DocumentEngine.test.js
+++ b/test/model/DocumentEngine.test.js
@@ -8,24 +8,28 @@ var ChangeStore = require('../../collab/ChangeStore');
 var DocumentEngine = require('../../collab/DocumentEngine');
 var testDocumentEngine = require('../collab/testDocumentEngine');
 
-var createTestDocumentFactory = require('../fixtures/createTestDocumentFactory');
-var twoParagraphs = require('../fixtures/twoParagraphs');
+var Configurator = require('../../util/Configurator');
+var TestArticle = require('./TestArticle');
+var TestMetaNode = require('./TestMetaNode');
+
 var documentStoreSeed = require('../fixtures/documentStoreSeed');
 var changeStoreSeed = require('../fixtures/changeStoreSeed');
+
+var configurator = new Configurator();
+configurator.defineSchema({
+  name: 'prose-article',
+  ArticleClass: TestArticle,
+  defaultTextType: 'paragraph'
+});
+configurator.addNode(TestMetaNode);
 
 var documentStore = new DocumentStore();
 var changeStore = new ChangeStore();
 
 var documentEngine = new DocumentEngine({
+  configurator: configurator,
   documentStore: documentStore,
-  changeStore: changeStore,
-  schemas: {
-    'prose-article': {
-      name: 'prose-article',
-      version: '1.0.0',
-      documentFactory: createTestDocumentFactory(twoParagraphs)
-    }
-  }
+  changeStore: changeStore
 });
 
 function setup(cb, t) {

--- a/ui/ResponsiveApplication.js
+++ b/ui/ResponsiveApplication.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var inBrowser = require('substance/util/inBrowser');
-var DefaultDOMElement = require('substance/ui/DefaultDOMElement');
-var Component = require('substance/ui/Component');
+var inBrowser = require('../util/inBrowser');
+var DefaultDOMElement = require('../ui/DefaultDOMElement');
+var Component = require('../ui/Component');
 var cloneDeep = require('lodash/cloneDeep');
 
 function ResponsiveApplication() {

--- a/util/AbstractConfigurator.js
+++ b/util/AbstractConfigurator.js
@@ -145,7 +145,7 @@ AbstractConfigurator.Prototype = function() {
     @param {String} label label.
 
     Define a new label
-    label is either a string or a hash with translations.
+    Label is either a string or a hash with translations.
     If string is provided 'en' is used as the language.
   */
   this.addLabel = function(labelName, label) {
@@ -162,6 +162,34 @@ AbstractConfigurator.Prototype = function() {
         this.config.labels[lang][labelName] = label;
       }.bind(this));
     }
+  };
+
+  /**
+    @param seed Seed function.
+
+    Define a seed function
+    Seed function is a transaction function.
+
+    @example
+
+    ```js
+    var seedFn = function(tx) {
+      var body = tx.get('body');
+
+      tx.create({
+        id: 'p1',
+        type: 'paragraph',
+        content: 'This is your new paragraph!'
+      });
+      body.show('p1');
+    };
+
+    config.addSeed(seedFn);
+    ```
+  */
+
+  this.addSeed = function(seed) {
+    this.config.seed = seed;
   };
 
   this.addTextType = function(textType, options) {
@@ -295,6 +323,10 @@ AbstractConfigurator.Prototype = function() {
 
   this.getIconProvider = function() {
     throw new Error('This method is abstract');
+  };
+
+  this.getSeed = function() {
+    return this.config.seed;
   };
 
   this.getTextTypes = function() {


### PR DESCRIPTION
@michael, @oliver---- pls merge.
Most notable change here is that documents are created now with 0 version, so editor will send transaction immediately with seed changes. It's what we did with factory functions on server before. Now we don't need any factory functions on server. It's fully compatible with old documents and I think much better. For example we could use different seed files within one setup.
I dropped out multiple schemas facility which we used before. I think it's good choice for now at least while we have single-schema-oriented configurator which we use now in document engine etc.
