### PR TITLE
(edit): Add scss files and add anon hash in server.js

### DIFF
--- a/doc/app.scss
+++ b/doc/app.scss
@@ -2,11 +2,11 @@ $fa-font-path:  "./fonts" !default;
 @import "../node_modules/font-awesome/scss/font-awesome";
 
 // Substance base styles
-@import '../styles/base/index';
+@import '../styles/base/_all';
 
 // Substance core and official packages
 @import '../styles/components/_all';
-@import '../packages/_all';
+@import '../packages/base/_all';
 
 // DocumentationReader component styles
 @import './styles/_variables';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lodash": "4.13.1"
   },
   "devDependencies": {
-    "browserify": "substance/node-browserify#d3caeb6dcdaa97a258d099c7231a57f0f60ec876",
+    "browserify": ">=10 <14",
+    "watchify" : ">=3 <4",
     "browserify-istanbul": "^2.0.0",
     "commonmark": "0.22.1",
     "coveralls": "^2.11.9",

--- a/packages/base/_all.scss
+++ b/packages/base/_all.scss
@@ -1,0 +1,17 @@
+@import '../base/_base.scss';
+@import '../blockquote/_blockquote.scss';
+@import '../code/_code.scss';
+@import '../codeblock/_codeblock.scss';
+@import '../emphasis/_emphasis.scss';
+@import '../heading/_heading.scss';
+@import '../image/_image.scss';
+@import '../inline-wrapper/_inline-wrapper.scss';
+@import '../link/_link.scss';
+@import '../list/_list.scss';
+@import '../paragraph/_paragraph.scss';
+@import '../prose-editor/_prose-editor.scss';
+@import '../strong/_strong.scss';
+@import '../subscript/_subscript.scss';
+@import '../superscript/_superscript.scss';
+@import '../table/_table.scss';
+

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ app.get('/docs/documentation.json', function(req, res) {
 });
 
 serverUtils.serveStyles(app, '/docs/app.css', {scssPath: path.join(__dirname, 'doc', 'app.scss')});
-serverUtils.serveJS(app, '/docs/app.js', path.join(__dirname, 'doc', 'app.js'));
+serverUtils.serveJS(app, '/docs/app.js', {sourcePath: path.join(__dirname, 'doc', 'app.js')});
 
 serverUtils.serveTestSuite(app, "test/**/*.test.js");
 


### PR DESCRIPTION
The PR has a few fixes that allow `npm install` and `npm start`.  The versions of browserify and watchify where chaanged to match the versions required in karma-browserify.  scss paths were fixed, or files added with scss paths.  In server.js the arg to serverJS was changed to a hash with key 'sourcePath' to match the structure of the serverUtils.serveStyles call.
