### PR TITLE
CheerioDOMElement fixes and others

### DIFF
--- a/collab/CollabClient.js
+++ b/collab/CollabClient.js
@@ -41,9 +41,9 @@ class CollabClient extends EventEmitter {
   */
   _onMessage(msg) {
     if (msg.scope === this.scope) {
-      this.emit('message', msg)
-    } else {
-      console.info('Message ignored. Not sent in hub scope', msg)
+      this.emit('message', msg);
+    } else if (msg.scope !== '_internal') {
+      console.info('Message ignored. Not sent in hub scope', msg);
     }
   }
 

--- a/model/NodeSelection.js
+++ b/model/NodeSelection.js
@@ -112,6 +112,10 @@ class NodeSelection extends Selection {
     }
   }
 
+  _clone() {
+    return new NodeSelection(this.containerId, this.nodeId, this.mode, this.reverse, this.surfaceId);
+  }
+
 }
 
 NodeSelection.fromJSON = function(json) {

--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
   "browser": {
     "cheerio": false,
     "dom-serializer": false
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   }
 }

--- a/packages/image/ImageHTMLConverter.js
+++ b/packages/image/ImageHTMLConverter.js
@@ -7,12 +7,12 @@ export default {
   tagName: 'img',
 
   import: function(el, node) {
-    node.src = el.attr('src');
-    node.previewSrc = el.attr('data-preview-src');
+    node.src = el.attr('src')
+    node.previewSrc = el.attr('data-preview-src')
   },
 
   export: function(node, el) {
     el.attr('src', node.src)
-      .attr('data-preview-src', node.previewSrc);
+    if (node.previewSrc) el.attr('data-preview-src', node.previewSrc)
   }
 }

--- a/packages/image/ImageXMLConverter.js
+++ b/packages/image/ImageXMLConverter.js
@@ -13,6 +13,6 @@ export default {
 
   export: function(node, el) {
     el.attr('src', node.src)
-      .attr('preview-src', node.previewSrc)
+    if (node.previewSrc) el.attr('preview-src', node.previewSrc)
   }
 }

--- a/ui/CheerioDOMElement.js
+++ b/ui/CheerioDOMElement.js
@@ -471,7 +471,11 @@ CheerioDOMElement.parseMarkup = function(str, format) {
     }
     return new CheerioDOMElement(doc)
   } else {
-    nativeEls = $.parseXML(str)
+    if (format === 'xml') {
+      nativeEls = $.parseXML(str)
+    } else {
+      nativeEls = $.parseHTML(str)
+    }
   }
   let elements = nativeEls.map(function(el) {
     return new CheerioDOMElement(el)

--- a/ui/CheerioDOMElement.js
+++ b/ui/CheerioDOMElement.js
@@ -253,7 +253,7 @@ class CheerioDOMElement extends DOMElement {
 
   isElementNode() {
     // cheerio specific
-    return this.el.type === "tag"
+    return this.el.type === "tag" || this.el.type === "script"
   }
 
   isCommentNode() {

--- a/ui/DefaultDOMElement.js
+++ b/ui/DefaultDOMElement.js
@@ -1,12 +1,11 @@
 import inBrowser from '../util/inBrowser'
-import BrowserDOMElement from './BrowserDOMElement.js'
-import CheerioDOMElement from './CheerioDOMElement.js'
 
 let DOMElementImpl
-
 if (inBrowser) {
+  var BrowserDOMElement = require('./BrowserDOMElement').default
   DOMElementImpl = BrowserDOMElement
 } else {
+  var CheerioDOMElement = require('./CheerioDOMElement').default
   DOMElementImpl = CheerioDOMElement
 }
 


### PR DESCRIPTION
Cheerio has a custom `type` attribute which it sets to `tag` for most elements but to `script` for scripts. This fix provides for consistent behaviour with `BrowserDOMElement`. Note that in both Chrome and Firefox `document.createElement('script').nodeType === window.Node.ELEMENT_NODE`
