### PR TITLE
Simplify Command API and added docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ dist/doc
 tmp
 .npm
 .test
-.doc
+.docs
 
 # IDE / Editor genereated files
 .idea

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Blockquote                                                                  | �
 Codeblock                                                                   | ✓
 Image                                                                       | ✓
 List                                                                        | Beta 6
-Table                                                                       | Beta 6
                                                                             |
 **Predefined annotation types**                                             |
 Strong                                                                      | ✓
@@ -53,7 +52,7 @@ Code                                                                        | �
                                                                             |
 **Platform support**                                                        |
 Mozilla Firefox (>=49)                                                      | ✓
-Apple Safari (>=10)                                                          | ✓
+Apple Safari (>=10)                                                         | ✓
 Google Chrome (>=53)                                                        | ✓
 Microsoft Edge                                                              | ✓
 
@@ -72,18 +71,18 @@ Run the dev server.
 npm start
 ```
 
-Navigate to `http://localhost:4201/docs` for the docs and `http://localhost:4201/test` for the test suite.
+Navigate to `http://localhost:5550/docs` for the docs and `http://localhost:5550/test` for the test suite. Test suite and docs are rebuilt as you make changes to the source files.
 
-To run the test-suite headless
+If you only work on the documentation, this recompiles faster.
+
+```
+npm run docs
+```
+
+To run the test-suite headless.
 
 ```
 $ npm test
-```
-
-To bundle the docs into a distribution:
-
-```
-$ npm run doc
 ```
 
 ## Roadmap
@@ -95,7 +94,6 @@ $ npm run doc
 - Key bindings
 - Improved Unicode support
 - List package
-- Table package
 
 ### 1.0 Final
 

--- a/collab/DocumentStore.js
+++ b/collab/DocumentStore.js
@@ -16,20 +16,20 @@ class DocumentStore {
 
     @return {Object} document record
   */
-  createDocument(props, cb) {
+  createDocument(params, cb) {
 
-    if (!props.documentId) {
+    if (!params.documentId) {
       // We generate a documentId ourselves
-      props.documentId = uuid()
+      params.documentId = uuid()
     }
 
-    let exists = this._documentExists(props.documentId);
+    let exists = this._documentExists(params.documentId);
     if (exists) {
       return cb(new Err('DocumentStore.CreateError', {
         message: 'Could not create because document already exists.'
       }))
     }
-    this._createDocument(props)
+    this._createDocument(params)
   }
 
   /*
@@ -48,14 +48,14 @@ class DocumentStore {
   /*
     Update document record
   */
-  updateDocument(documentId, newProps, cb) {
+  updateDocument(documentId, newparams, cb) {
     let exists = this._documentExists(documentId)
     if (!exists) {
       return cb(new Err('DocumentStore.UpdateError', {
         message: 'Document does not exist.'
       }))
     }
-    this._updateDocument(documentId, newProps)
+    this._updateDocument(documentId, newparams)
     cb(null, this._getDocument(documentId))
   }
 
@@ -92,8 +92,8 @@ class DocumentStore {
   // Handy synchronous helpers
   // -------------------------
 
-  _createDocument(props) {
-    this._documents[props.documentId] = props
+  _createDocument(params) {
+    this._documents[params.documentId] = params
   }
 
   _deleteDocument(documentId) {
@@ -105,9 +105,9 @@ class DocumentStore {
     return this._documents[documentId]
   }
 
-  _updateDocument(documentId, props) {
+  _updateDocument(documentId, params) {
     let doc = this._documents[documentId]
-    extend(doc, props)
+    extend(doc, params)
   }
 
   _documentExists(documentId) {

--- a/make.js
+++ b/make.js
@@ -5,7 +5,7 @@ var docgenConfig = require('./.docgenrc')
 b.task('clean', function() {
   b.rm('./dist');
   b.rm('./.test');
-  b.rm('./.doc');
+  b.rm('./.docs');
   b.rm('./.npm');
 });
 
@@ -113,7 +113,7 @@ var NPMDIST = NPM+'dist/'
 
 b.task('npm:clean', function() {
   b.rm(NPM)
-  b.rm('.doc')
+  b.rm('.docs')
 })
 
 b.task('npm:copy:js', function() {
@@ -132,7 +132,7 @@ b.task('npm:copy:css', function() {
 
 // a fully debuggable version of the docgenerator
 b.task('docs', function() {
-  b.copy('node_modules/substance-docgen/dist/reader/**/*', '.doc/', {root: 'node_modules/substance-docgen/dist/reader'})
+  b.copy('node_modules/substance-docgen/dist/reader/**/*', '.docs/', {root: 'node_modules/substance-docgen/dist/reader'})
   b.custom('Bundling sourcefiles for docgen...', {
     src: [
       './*.md',
@@ -143,19 +143,19 @@ b.task('docs', function() {
       './ui/*.js',
       './util/*.js',
     ],
-    dest: '.doc/data.js',
+    dest: '.docs/data.js',
     execute: function(files) {
       var bundleSources = require('substance-docgen/bundleSources')
       files = files.map(function(file) {
         return path.relative(__dirname, file)
       })
-      bundleSources(files, '.doc/data.js', docgenConfig)
+      bundleSources(files, '.docs/data.js', docgenConfig)
     }
   })
 })
 
 b.task('npm:docs', ['docs'], function() {
-  b.copy('.doc', NPM+'doc')
+  b.copy('.docs', NPM+'doc')
 })
 
 b.task('npm:js', function() {
@@ -184,7 +184,7 @@ b.task('npm', ['npm:clean', 'npm:copy:js', 'npm:copy:css', 'npm:docs', 'npm:js',
 b.task('default', ['build'])
 
 // Default dev mode, only browser bundles are made and no ES5 transpilation happens
-b.task('dev', ['clean', 'css', 'browser', 'test:clean', 'test:assets', 'test:browser:pure'])
+b.task('dev', ['clean', 'css', 'browser', 'test:assets', 'test:browser:pure' , 'docs'])
 
 // SERVER
 
@@ -192,4 +192,4 @@ b.task('dev', ['clean', 'css', 'browser', 'test:clean', 'test:assets', 'test:bro
 b.setServerPort(5550)
 b.serve({ static: true, route: '/', folder: 'dist' })
 b.serve({ static: true, route: '/test/', folder: '.test' })
-b.serve({ static: true, route: '/doc/', folder: '.doc' })
+b.serve({ static: true, route: '/docs/', folder: '.docs' })

--- a/model/data/Node.js
+++ b/model/data/Node.js
@@ -7,7 +7,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import each from 'lodash/each'
 import EventEmitter from '../../util/EventEmitter'
 
-/**
+/*
   Base node implementation.
 
   @prop {String} id an id that is unique within this data

--- a/model/transform/createAnnotation.js
+++ b/model/transform/createAnnotation.js
@@ -22,18 +22,10 @@ import helpers from '../documentHelpers'
   });
   ```
 */
-
 function createAnnotation(tx, args) {
   let sel = args.selection
   if (!sel) throw new Error('selection is required.')
-  let annoType = args.annotationType
-  let annoData = args.annotationData
   let anno = args.node
-  if (!anno && annoType) {
-    console.warn('DEPRECATED: Use node: {type: "strong"} instead of annotationType: "strong"')
-    anno = { type: annoType }
-    extend(anno, annoData)
-  }
   if (!anno) throw new Error('node is required')
 
   if (!sel.isPropertySelection() && !sel.isContainerSelection() || sel.isCollapsed()) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "jsnext:main": "dist/substance.es6.js",
   "scripts": {
     "test": "node test",
-    "doc": "node make npm:docs",
+    "docs": "node make docs -w -s",
     "start": "node make dev -w -s"
   },
   "author": "",

--- a/packages/base/RedoCommand.js
+++ b/packages/base/RedoCommand.js
@@ -2,16 +2,16 @@ import Command from '../../ui/Command'
 
 class Redo extends Command {
 
-  getCommandState(props, context) {
-    let docSession = context.documentSession
+  getCommandState(params) {
+    let docSession = params.documentSession
     return {
       disabled: !docSession.canRedo(),
       active: false
     }
   }
 
-  execute(props, context) {
-    let docSession = context.documentSession
+  execute(params) {
+    let docSession = params.documentSession
     if (docSession.canRedo()) {
       docSession.redo()
       return true

--- a/packages/base/UndoCommand.js
+++ b/packages/base/UndoCommand.js
@@ -2,16 +2,16 @@ import Command from '../../ui/Command'
 
 class Undo extends Command {
 
-  getCommandState(props, context) {
-    let docSession = context.documentSession
+  getCommandState(params) {
+    let docSession = params.documentSession
     return {
       disabled: !docSession.canUndo(),
       active: false
     }
   }
 
-  execute(props, context) {
-    let docSession = context.documentSession
+  execute(params) {
+    let docSession = params.documentSession
     if (docSession.canUndo()) {
       docSession.undo()
       return true

--- a/packages/image/InsertImageCommand.js
+++ b/packages/image/InsertImageCommand.js
@@ -6,10 +6,10 @@ class ImageCommand extends Command {
     super({ name: 'insert-image' })
   }
 
-  getCommandState(props, context) {
+  getCommandState(params, context) {
     let documentSession = context.documentSession
-    let sel = props.selection || documentSession.getSelection()
-    let surface = props.surface || context.surfaceManager.getFocusedSurface()
+    let sel = params.selection || documentSession.getSelection()
+    let surface = params.surface || context.surfaceManager.getFocusedSurface()
     let newState = {
       disabled: true,
       active: false
@@ -25,16 +25,16 @@ class ImageCommand extends Command {
     Inserts (stub) images and triggers a fileupload.
     After upload has completed, the image URLs get updated.
   */
-  execute(props, context) {
-    let state = this.getCommandState(props, context)
+  execute(params, context) {
+    let state = this.getCommandState(params, context)
     // Return if command is disabled
     if (state.disabled) return
 
     let documentSession = context.documentSession
-    let sel = props.selection || documentSession.getSelection()
-    let surface = props.surface || context.surfaceManager.getFocusedSurface()
+    let sel = params.selection || documentSession.getSelection()
+    let surface = params.surface || context.surfaceManager.getFocusedSurface()
     let fileClient = context.fileClient
-    let files = props.files
+    let files = params.files
 
     // can drop images only into container editors
     if (!surface.isContainerEditor()) return

--- a/packages/image/InsertImageCommand.js
+++ b/packages/image/InsertImageCommand.js
@@ -6,10 +6,9 @@ class ImageCommand extends Command {
     super({ name: 'insert-image' })
   }
 
-  getCommandState(params, context) {
-    let documentSession = context.documentSession
-    let sel = params.selection || documentSession.getSelection()
-    let surface = params.surface || context.surfaceManager.getFocusedSurface()
+  getCommandState(params) {
+    let sel = params.selection
+    let surface = params.surface
     let newState = {
       disabled: true,
       active: false
@@ -26,13 +25,13 @@ class ImageCommand extends Command {
     After upload has completed, the image URLs get updated.
   */
   execute(params, context) {
-    let state = this.getCommandState(params, context)
+    let state = this.getCommandState(params)
     // Return if command is disabled
     if (state.disabled) return
 
-    let documentSession = context.documentSession
-    let sel = params.selection || documentSession.getSelection()
-    let surface = params.surface || context.surfaceManager.getFocusedSurface()
+    let documentSession = params.documentSession
+    let sel = params.selection
+    let surface = params.surface
     let fileClient = context.fileClient
     let files = params.files
 

--- a/packages/inline-node/EditInlineNodeCommand.js
+++ b/packages/inline-node/EditInlineNodeCommand.js
@@ -3,18 +3,18 @@ import Command from '../../ui/Command'
 class EditInlineNodeCommand extends Command {
   constructor(...args) {
     super(...args)
-    if (!this.params.nodeType) {
+    if (!this.config.nodeType) {
       throw new Error('Every AnnotationCommand must have a nodeType')
     }
   }
 
-  getCommandState(props, context) {
+  getCommandState(params, context) {
     let sel = context.documentSession.getSelection()
     let newState = {
       disabled: true,
       active: false
     }
-    let annos = this._getAnnotationsForSelection(props, context)
+    let annos = this._getAnnotationsForSelection(params, context)
     if (annos.length === 1 && annos[0].getSelection().equals(sel)) {
       newState.disabled = false
       newState.node = annos[0]
@@ -22,12 +22,12 @@ class EditInlineNodeCommand extends Command {
     return newState
   }
 
-  execute(props, context) { // eslint-disable-line
+  execute(params, context) { // eslint-disable-line
 
   }
 
-  _getAnnotationsForSelection(props) {
-    return props.selectionState.getAnnotationsForType(this.params.nodeType)
+  _getAnnotationsForSelection(params) {
+    return params.selectionState.getAnnotationsForType(this.config.nodeType)
   }
 
 }

--- a/packages/inline-node/EditInlineNodeCommand.js
+++ b/packages/inline-node/EditInlineNodeCommand.js
@@ -8,13 +8,13 @@ class EditInlineNodeCommand extends Command {
     }
   }
 
-  getCommandState(params, context) {
-    let sel = context.documentSession.getSelection()
+  getCommandState(params) {
+    let sel = params.selection
     let newState = {
       disabled: true,
       active: false
     }
-    let annos = this._getAnnotationsForSelection(params, context)
+    let annos = this._getAnnotationsForSelection(params)
     if (annos.length === 1 && annos[0].getSelection().equals(sel)) {
       newState.disabled = false
       newState.node = annos[0]
@@ -22,7 +22,7 @@ class EditInlineNodeCommand extends Command {
     return newState
   }
 
-  execute(params, context) { // eslint-disable-line
+  execute(params) { // eslint-disable-line
 
   }
 

--- a/packages/inline-node/InsertInlineNodeCommand.js
+++ b/packages/inline-node/InsertInlineNodeCommand.js
@@ -1,16 +1,47 @@
 import Command from '../../ui/Command'
 import insertInlineNode from '../../model/transform/insertInlineNode'
 
+/**
+  Reusable command implementation for inserting inline nodes.
+
+  @class InsertInlineNodeCommand
+
+  @example
+
+  ```
+  class AddXRefCommand extends InsertInlineNodeCommand {
+    createNodeData() {
+      return {
+        attributes: {'ref-type': 'bibr'},
+        targets: [],
+        label: '???',
+        type: 'xref'
+      }
+    }
+  }
+  ```
+
+  In configurator
+  ```
+  config.addCommand('add-xref', AddXRefCommand, {nodeType: 'xref'})
+  ```
+*/
+
+/** INCLUDE_IN_API_DOCS */
 class InsertInlineNodeCommand extends Command {
   constructor(...args) {
     super(...args)
 
-    if (!this.params.nodeType) {
-      throw new Error('Every AnnotationCommand must have a nodeType')
+    if (!this.config.nodeType) {
+      throw new Error('Every InlineInlineNodeCommand must have a nodeType')
     }
   }
 
-  getCommandState(props, context) {
+  /**
+    Determine command state for inline node insertion. Command is enabled
+    if selection is a property selection.
+  */
+  getCommandState(params, context) {
     let sel = context.documentSession.getSelection()
     let newState = {
       disabled: !sel.isPropertySelection(),
@@ -19,8 +50,11 @@ class InsertInlineNodeCommand extends Command {
     return newState
   }
 
-  execute(props, context) {
-    let state = this.getCommandState(props, context)
+  /**
+    Insert new inline node at the current selection
+  */
+  execute(params, context) {
+    let state = this.getCommandState(params, context)
     if (state.disabled) return
     let surface = context.surface || context.surfaceManager.getFocusedSurface()
     if (surface) {
@@ -38,12 +72,12 @@ class InsertInlineNodeCommand extends Command {
 
   createNodeData(tx, args) { // eslint-disable-line
     return {
-      type: this.params.nodeType
+      type: this.config.nodeType
     }
   }
 
-  _getAnnotationsForSelection(props) {
-    return props.selectionState.getAnnotationsForType(this.params.nodeType)
+  _getAnnotationsForSelection(params) {
+    return params.selectionState.getAnnotationsForType(this.config.nodeType)
   }
 
 }

--- a/packages/inline-node/InsertInlineNodeCommand.js
+++ b/packages/inline-node/InsertInlineNodeCommand.js
@@ -8,6 +8,8 @@ import insertInlineNode from '../../model/transform/insertInlineNode'
 
   @example
 
+  Define a custom command.
+
   ```
   class AddXRefCommand extends InsertInlineNodeCommand {
     createNodeData() {
@@ -21,14 +23,17 @@ import insertInlineNode from '../../model/transform/insertInlineNode'
   }
   ```
 
-  In configurator
+  Register it in your app using the configurator.
+
   ```
   config.addCommand('add-xref', AddXRefCommand, {nodeType: 'xref'})
   ```
 */
 
-/** INCLUDE_IN_API_DOCS */
 class InsertInlineNodeCommand extends Command {
+  /**
+    @param config Takes a config object, provided on registration in configurator
+  */
   constructor(...args) {
     super(...args)
 
@@ -41,8 +46,8 @@ class InsertInlineNodeCommand extends Command {
     Determine command state for inline node insertion. Command is enabled
     if selection is a property selection.
   */
-  getCommandState(params, context) {
-    let sel = context.documentSession.getSelection()
+  getCommandState(params) {
+    let sel = params.selection
     let newState = {
       disabled: !sel.isPropertySelection(),
       active: false
@@ -53,10 +58,10 @@ class InsertInlineNodeCommand extends Command {
   /**
     Insert new inline node at the current selection
   */
-  execute(params, context) {
-    let state = this.getCommandState(params, context)
+  execute(params) {
+    let state = this.getCommandState(params)
     if (state.disabled) return
-    let surface = context.surface || context.surfaceManager.getFocusedSurface()
+    let surface = params.surface
     if (surface) {
       surface.transaction(function(tx, args) {
         return this.insertInlineNode(tx, args)
@@ -74,10 +79,6 @@ class InsertInlineNodeCommand extends Command {
     return {
       type: this.config.nodeType
     }
-  }
-
-  _getAnnotationsForSelection(params) {
-    return params.selectionState.getAnnotationsForType(this.config.nodeType)
   }
 
 }

--- a/packages/persistence/SaveCommand.js
+++ b/packages/persistence/SaveCommand.js
@@ -5,16 +5,16 @@ class SaveCommand extends Command {
     super({ name: 'save' })
   }
 
-  getCommandState(props, context) {
-    let dirty = context.documentSession.isDirty()
+  getCommandState(params) {
+    let dirty = params.documentSession.isDirty()
     return {
       disabled: !dirty,
       active: false
     }
   }
 
-  execute(props, context) {
-    let documentSession = context.documentSession
+  execute(params) {
+    let documentSession = params.documentSession
     documentSession.save()
     return {
       status: 'saving-process-started'

--- a/packages/switch-text-type/SwitchTextTypeCommand.js
+++ b/packages/switch-text-type/SwitchTextTypeCommand.js
@@ -6,8 +6,8 @@ import _clone from 'lodash/clone'
 class SwitchTextTypeCommand extends Command {
 
   // Available text types on the surface
-  getTextTypes(context) {
-    let surface = context.surfaceManager.getFocusedSurface()
+  getTextTypes(params) {
+    let surface = params.surface
     if (surface && surface.isContainerEditor()) {
       return surface.getTextTypes()
     } else {
@@ -15,8 +15,8 @@ class SwitchTextTypeCommand extends Command {
     }
   }
 
-  getTextType(context, textTypeName) {
-    let textTypes = this.getTextTypes(context)
+  getTextType(params, textTypeName) {
+    let textTypes = this.getTextTypes()
     return _find(textTypes, function(t) {
       return t.name === textTypeName
     })
@@ -24,8 +24,8 @@ class SwitchTextTypeCommand extends Command {
 
   // Search which textType matches the current node
   // E.g. {type: 'heading', level: 1} => heading1
-  getCurrentTextType(context, node) {
-    let textTypes = this.getTextTypes(context)
+  getCurrentTextType(params, node) {
+    let textTypes = this.getTextTypes(params)
     let currentTextType
     textTypes.forEach(function(textType) {
       let nodeProps = _clone(textType.data)
@@ -37,14 +37,14 @@ class SwitchTextTypeCommand extends Command {
     return currentTextType
   }
 
-  getCommandState(props, context) {
-    let doc = context.documentSession.getDocument()
-    let sel = context.documentSession.getSelection()
-    let surface = context.surfaceManager.getFocusedSurface()
+  getCommandState(params) {
+    let doc = params.documentSession.getDocument()
+    let sel = params.selection
+    let surface = params.surface
     let node
     let newState = {
       disabled: false,
-      textTypes: this.getTextTypes(context)
+      textTypes: this.getTextTypes(params)
     }
     // Set disabled when not a property selection
     if (!surface || !surface.isEnabled() || sel.isNull()) {
@@ -59,7 +59,7 @@ class SwitchTextTypeCommand extends Command {
       // so we need to guard node
       if (node) {
         if (node.isText() && node.isBlock()) {
-          newState.currentTextType = this.getCurrentTextType(context, node)
+          newState.currentTextType = this.getCurrentTextType(params, node)
         }
         if (!newState.currentTextType) {
           // We 'abuse' the currentTextType field by providing a property
@@ -82,13 +82,11 @@ class SwitchTextTypeCommand extends Command {
 
   /**
     Trigger a switchTextType transaction
-
-    @param {String} textTypeName identifier (e.g. heading1)
   */
-  execute(props, context) {
-    let textType = this.getTextType(context, props.textType)
+  execute(params) {
+    let textType = this.getTextType(params.textType)
     let nodeData = textType.data
-    let surface = context.surfaceManager.getFocusedSurface()
+    let surface = params.surface
     if (!surface) {
       console.warn('No focused surface. Stopping command execution.')
       return

--- a/test/ui/AnnotationCommand.test.js
+++ b/test/ui/AnnotationCommand.test.js
@@ -48,7 +48,9 @@ test("execute 'create' property annotation", function(t) {
   var sel = doc.createSelection(['p6', 'content'], 1, 6)
   docSession.setSelection(sel)
   var res = cmd.execute({
-    mode: 'create',
+    commandState: {
+      mode: 'create'
+    },
     documentSession: docSession,
     selectionState: docSession.getSelectionState()
   })
@@ -95,7 +97,9 @@ test("can 'expand' property annotation", function(t) {
   var sel = doc.createSelection(['p1', 'content'], 5, 7)
   docSession.setSelection(sel)
   cmd.execute({
-    mode: 'delete',
+    commandState: {
+      mode: 'delete'
+    },
     documentSession: docSession,
     selectionState: docSession.getSelectionState()
   })

--- a/ui/AbstractEditor.js
+++ b/ui/AbstractEditor.js
@@ -86,8 +86,7 @@ class AbstractEditor extends Component {
   getCommandContext() {
     return {
       documentSession: this.documentSession,
-      surfaceManager: this.surfaceManager,
-      converterRegistry: this.converterRegistry
+      surfaceManager: this.surfaceManager
     }
   }
 

--- a/ui/Command.js
+++ b/ui/Command.js
@@ -1,14 +1,43 @@
-
 /**
- Abstract interface for commands.
+  Commands are used to perform UI triggered actions on the document. For instance the
+  {@link ui/AnnotationCommand} takes care of creating, expanding, truncating and
+  deleting annotations such as strong and emphasis. It does so by determining a
+  commandState by inspecting the current selection, which is used to parametrize
+  the corresponding tool component. E.g. the strong tool gets active and clickable
+  in create mode when a word in the text is selected. Triggered by a click on the tool,
+  or a keyboard shortcut, the command gets executed by running the code specified in the
+  execute method.
 
- @class
+  @class Command
+  @abstract
+
+  @example
+
+  ```
+  class MyCommand extends Command {
+    getCommandState(props, context) {
+      // determine commandState based on props and context
+    }
+
+    execute(props, context) {
+      // perform operations on the document
+    }
+  }
+  ```
 */
 
+/** INCLUDE_IN_API_DOCS */
 class Command {
-  constructor(params) {
-    this.params = params || {}
-    this.name = this.params.name
+
+  /**
+    Construcutor is only used internally.
+
+    @constructor
+    @param {Object} config    Config provided during command registration
+  */
+  constructor(config) {
+    this.config = config || {}
+    this.name = this.config.name
     if (!this.name) {
       throw new Error("'name' is required");
     }
@@ -18,34 +47,49 @@ class Command {
     return true
   }
 
+  /**
+    Get the command name specified at command registration. See
+    {@link util/Configurator#addCommand}
+  */
   getName() {
     return this.name
   }
 
-  getCommandState(props, context) { // eslint-disable-line
+  /**
+    Determines command state, based on passed params and context. The command
+    state is usually used as props for tool components.
+
+    For an example implementation see {@link ui/EditAnnotation#getCommandState}
+
+    @param {Object} params      Provides documentSession, selectionState, surface, selection
+    @param {Object} context     Provides app-specific context.
+  */
+  getCommandState(params, context) { // eslint-disable-line
     throw new Error('Command.getCommandState() is abstract.')
   }
 
   /**
-    Execute command
+    Execute command and perform operations on the document
 
-    @abstract
+    @param {Object} params      Provides commandState, documentSession, selectionState, surface, selection
+    @param {Object} context     Provides app-specific context.
+
     @return {Object} info object with execution details
   */
-  execute(props, context) { // eslint-disable-line
+  execute(params, context) { // eslint-disable-line
     throw new Error('Command.execute() is abstract.')
   }
 
-  _getDocumentSession(props, context) {
-    let docSession = props.documentSession || context.documentSession
+  _getDocumentSession(params, context) {
+    let docSession = params.documentSession || context.documentSession
     if (!docSession) {
       throw new Error("'documentSession' is required.")
     }
     return docSession
   }
 
-  _getSelection(props) {
-    let sel = props.selection || props.selectionState.getSelection()
+  _getSelection(params) {
+    let sel = params.selection || params.selectionState.getSelection()
     if (!sel) {
       throw new Error("'selection' is required.")
     }
@@ -53,6 +97,5 @@ class Command {
   }
 
 }
-
 
 export default Command

--- a/ui/EditAnnotationCommand.js
+++ b/ui/EditAnnotationCommand.js
@@ -10,15 +10,14 @@ class EditAnnotationCommand extends Command {
   constructor(...args) {
     super(...args)
 
-    if (!this.params.nodeType) {
+    if (!this.config.nodeType) {
       throw new Error("'nodeType' is required")
     }
   }
 
-  getCommandState(props, context) { // eslint-disable-line
-    context = context || {}
-    let sel = this._getSelection(props)
-    let annos = this._getAnnotationsForSelection(props, context)
+  getCommandState(params) {
+    let sel = this._getSelection(params)
+    let annos = this._getAnnotationsForSelection(params)
     let newState = {
       disabled: true,
     }
@@ -30,10 +29,10 @@ class EditAnnotationCommand extends Command {
     return newState
   }
 
-  execute(props, context) { } // eslint-disable-line
+  execute(params) { } // eslint-disable-line
 
-  _getAnnotationsForSelection(props) {
-    return props.selectionState.getAnnotationsForType(this.params.nodeType)
+  _getAnnotationsForSelection(params) {
+    return params.selectionState.getAnnotationsForType(this.config.nodeType)
   }
 }
 

--- a/ui/InsertNodeCommand.js
+++ b/ui/InsertNodeCommand.js
@@ -3,8 +3,8 @@ import insertNode from '../model/transform/insertNode'
 
 class InsertNodeCommand extends Command {
 
-  getCommandState(props, context) {
-    let sel = context.documentSession.getSelection();
+  getCommandState(params) {
+    let sel = params.selection
     let newState = {
       disabled: true,
       active: false
@@ -15,10 +15,10 @@ class InsertNodeCommand extends Command {
     return newState
   }
 
-  execute(props, context) {
-    var state = this.getCommandState(props, context)
+  execute(params) {
+    var state = params.commandState
     if (state.disabled) return
-    var surface = context.surface ||context.surfaceManager.getFocusedSurface()
+    var surface = params.surface
     if (surface) {
       surface.transaction(function(tx, args) {
         return this.insertNode(tx, args)

--- a/util/Configurator.js
+++ b/util/Configurator.js
@@ -5,12 +5,10 @@ import DocumentSchema from '../model/DocumentSchema'
 import EditingBehavior from '../model/EditingBehavior'
 import Registry from '../util/Registry'
 import ComponentRegistry from '../ui/ComponentRegistry'
-
-// Default icon and label provider
 import FontAwesomeIconProvider from '../ui/FontAwesomeIconProvider'
 import LabelProvider from '../ui/DefaultLabelProvider'
 
-/*
+/**
   Default Configurator for Substance editors. It provides an API for
   adding nodes to the schema, components, commands and tools etc.
 
@@ -52,6 +50,8 @@ import LabelProvider from '../ui/DefaultLabelProvider'
   sure you don't run into cyclic dependencies as there is no checking for
   that at the moment.
 */
+
+/** INCLUDE_IN_API_DOCS */
 class Configurator {
   constructor() {
     this.config = {


### PR DESCRIPTION
Simplified command implementations to rely on params only. context is only needed if the user wants to access some app-specific objects and led to confusions, so I dropped it where it’s not needed.

@oliver---- pls review.

Fixes #825.
