### PR TITLE
Docgen fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist/doc
 tmp
 .npm
 .test
+.doc
 .docs
 
 # IDE / Editor genereated files

--- a/model/Document.js
+++ b/model/Document.js
@@ -115,7 +115,7 @@ class Document extends EventEmitter {
     @returns {Boolean} `true` if a node with id exists, `false` otherwise.
   */
   contains(id) {
-    this.data.contains(id)
+    return this.data.contains(id)
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "karma-tap": "1.0.4",
     "karma-tape-reporter": "1.0.3",
     "substance-bundler": "0.4.25",
-    "substance-docgen": "0.3.x",
+    "substance-docgen": "0.3.5",
     "substance-test": "^0.2.3"
   },
   "browser": {

--- a/ui/Command.js
+++ b/ui/Command.js
@@ -15,11 +15,11 @@
 
   ```
   class MyCommand extends Command {
-    getCommandState(props, context) {
-      // determine commandState based on props and context
+    getCommandState(params, context) {
+      // determine commandState based on params and context
     }
 
-    execute(props, context) {
+    execute(params, context) {
       // perform operations on the document
     }
   }
@@ -57,7 +57,24 @@ class Command {
     Determines command state, based on passed params and context. The command
     state is usually used as props for tool components.
 
-    For an example implementation see {@link ui/EditAnnotation#getCommandState}
+    @example
+
+    This shows the implementation of {@link EditAnnotationCommand#getCommandState}
+
+    ```
+    getCommandState(params) {
+      const sel = this._getSelection(params)
+      const annos = params.selectionState.getAnnotationsForType(this.config.nodeType)
+      const newState = {
+        disabled: true,
+      }
+
+      if (annos.length === 1 && sel.isPropertySelection()) {
+        newState.disabled = false
+        newState.node = annos[0]
+      }
+    }
+    ```
 
     @param {Object} params      Provides documentSession, selectionState, surface, selection
     @param {Object} context     Provides app-specific context.

--- a/ui/Component.js
+++ b/ui/Component.js
@@ -101,7 +101,6 @@ class Component extends DOMElement.Delegator {
   /**
     Construcutor is only used internally.
 
-    @constructor
     @param {Component} parent The parent component
     @param {Object} props     Properties against which this class must
                               be rendered the first time.

--- a/ui/Component.js
+++ b/ui/Component.js
@@ -64,17 +64,17 @@ var __id__ = 0
 
   ### Lifecycle hooks
 
-  The {@link ui/RenderingEngine} triggers a set of hooks for you to define behavior
+  The {@link RenderingEngine} triggers a set of hooks for you to define behavior
   in various stages of the rendering cycle. The names are pretty self
   explanatory. If in doubt, please check out the method documentation below.
 
-  1. {@link ui/Component#didMount}
-  1. {@link ui/Component#didUpdate}
-  1. {@link ui/Component#dispose}
-  1. {@link ui/Component#willReceiveProps}
-  1. {@link ui/Component#willUpdateState}
+  1. {@link Component#didMount}
+  1. {@link Component#didUpdate}
+  1. {@link Component#dispose}
+  1. {@link Component#willReceiveProps}
+  1. {@link Component#willUpdateState}
 
-  @implements util/EventEmitter
+  @implements EventEmitter
 
   @example
 
@@ -172,8 +172,8 @@ class Component extends DOMElement.Delegator {
   /**
     Override this within your component to provide the initial state for the
     component. This method is internally called by the
-    {@link ui/RenderingEngine} and the state defined here is made available to
-    the {@link ui/Component#render} method as this.state.
+    {@link RenderingEngine} and the state defined here is made available to
+    the {@link Component#render} method as this.state.
 
     @return {Object} the initial state
   */

--- a/ui/EditAnnotationCommand.js
+++ b/ui/EditAnnotationCommand.js
@@ -15,6 +15,11 @@ class EditAnnotationCommand extends Command {
     }
   }
 
+  /**
+    Get command state
+
+    @return {Object} object with `disabled` and `node` properties
+  */
   getCommandState(params) {
     let sel = this._getSelection(params)
     let annos = this._getAnnotationsForSelection(params)

--- a/ui/VirtualElement.js
+++ b/ui/VirtualElement.js
@@ -12,10 +12,10 @@ import without from 'lodash/without'
 import DOMElement from './DOMElement'
 
 /**
-  A virtual {@link ui/DOMElement} which is used by the {@link ui/Component} API.
+  A virtual {@link DOMElement} which is used by the {@link Component} API.
 
   A VirtualElement is just a description of a DOM structure. It represents a virtual
-  DOM mixed with Components. This virtual structure needs to be compiled to a {@link ui/Component}
+  DOM mixed with Components. This virtual structure needs to be compiled to a {@link Component}
   to actually create a real DOM element.
 
   @class


### PR DESCRIPTION
- Fixed #831 
- Smart id lookup

I'd like to avoid using unqualified internal ids (such as `Component` instead of `ui/Component`) cause of name-clashes. We now have a LinkProvider which is mapping unqualified ids to qualified ones. As long there are no name clashes of the 'simple' names, this works as expected.
