### PR TITLE
v1.0.0-beta.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substance",
-  "version": "1.0.0-beta.5.5",
+  "version": "1.0.0-beta.5.6",
   "description": "",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "karma-tap": "1.0.4",
     "karma-tape-reporter": "1.0.3",
     "substance-bundler": "0.5.1",
-    "substance-docgen": "0.4.6",
+    "substance-docgen": "0.4.7",
     "substance-test": "^0.2.3"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substance",
-  "version": "1.0.0-beta.5.7",
+  "version": "1.0.0-beta.5.8",
   "description": "",
   "repository": {
     "type": "git",
@@ -46,6 +46,7 @@
     "ui",
     "util",
     "*.css",
+    "*.js",
     "*.md",
     "packages.json"
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "substance",
-  "version": "1.0.0-beta.5.6",
+  "version": "1.0.0-beta.5.7",
   "description": "",
   "repository": {
     "type": "git",
@@ -35,5 +35,18 @@
   },
   "browser": {
     "substance-cheerio": false
-  }
+  },
+  "files": [
+    "collab",
+    "dist",
+    "docs",
+    "model",
+    "packages",
+    "test",
+    "ui",
+    "util",
+    "*.css",
+    "*.md",
+    "packages.json"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-tape-reporter": "1.0.3",
     "substance-bundler": "0.5.1",
     "substance-docgen": "0.4.7",
-    "substance-test": "^0.2.3"
+    "substance-test": "0.2.6"
   },
   "browser": {
     "substance-cheerio": false


### PR DESCRIPTION
- Fixed npm publish configuration: `dist` folder was missing.
- Updated substance-test and substance-docgen to a version which use published substance
