### PR TITLE
Fix content-type header.

### DIFF
--- a/util/request.js
+++ b/util/request.js
@@ -18,7 +18,7 @@
 function request(method, url, data, cb) {
   var request = new XMLHttpRequest()
   request.open(method, url, true)
-  request.setRequestHeader('Content-Type', 'application/json charset=UTF-8')
+  request.setRequestHeader('Content-Type', 'application/json; charset=UTF-8')
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {
       var res = request.responseText


### PR DESCRIPTION
Content-type must be separated from charset with semicolon. This causing problems with some versions of express. Pls merge.