### PR TITLE
Improved interaction for Link tools (overlay)

### DIFF
--- a/packages/link/LinkCommand.js
+++ b/packages/link/LinkCommand.js
@@ -1,10 +1,20 @@
 import AnnotationCommand from '../../ui/AnnotationCommand'
 
 class LinkCommand extends AnnotationCommand {
-
   canFuse() { return false }
 
-  canDelete() { return false }
+  /*
+    On link creation we collapse the selection, as this is a condition for the
+    EditLinkTool to be shown (see EditAnnotationCommand)
+  */
+  executeCreate(params) {
+    let result = super.executeCreate(params)
+    let editorSession = this._getEditorSession(params)
+    editorSession.transaction((tx) => {
+      tx.setSelection(tx.selection.collapse())
+    })
+    return result
+  }
 }
 
 export default LinkCommand

--- a/packages/link/LinkPackage.js
+++ b/packages/link/LinkPackage.js
@@ -10,15 +10,21 @@ import platform from '../../util/platform'
 
 export default {
   name: 'link',
-  configure: function(config, {toolGroup, editLinkToolGroup, disableCollapsedCursor}) {
+  configure: function(config, {
+    toolGroup,
+    editLinkToolGroup,
+    disableCollapsedCursor
+  }) {
     config.addNode(Link)
     config.addComponent('link', LinkComponent)
     config.addConverter('html', LinkHTMLConverter)
     config.addConverter('xml', LinkXMLConverter)
-    config.addCommand('link', LinkCommand, {nodeType: 'link'})
-    config.addCommand('edit-link', EditAnnotationCommand, {
+    config.addCommand('link', LinkCommand, {
       nodeType: 'link',
       disableCollapsedCursor
+    })
+    config.addCommand('edit-link', EditAnnotationCommand, {
+      nodeType: 'link'
     })
     config.addTool('link', AnnotationTool, {
       toolGroup: toolGroup || 'annotations'

--- a/ui/AnnotationCommand.js
+++ b/ui/AnnotationCommand.js
@@ -233,7 +233,7 @@ class AnnotationCommand extends Command {
     let annoData = this.getAnnotationData()
     annoData.type = this.getAnnotationType()
     let anno
-    editorSession.transaction((tx)=>{
+    editorSession.transaction((tx) => {
       anno = tx.annotate(annoData)
     })
     return {

--- a/ui/EditAnnotationCommand.js
+++ b/ui/EditAnnotationCommand.js
@@ -26,7 +26,7 @@ class EditAnnotationCommand extends Command {
     let newState = {
       disabled: true,
     }
-    if (annos.length === 1 && sel.isPropertySelection()) {
+    if (annos.length === 1 && sel.isPropertySelection() && sel.isCollapsed()) {
       newState.disabled = false
       newState.node = annos[0]
     }


### PR DESCRIPTION
In an overlay-only scenario we now show the EditLinkTool for a collapsed selection touching the link. When the selection is expanded the other annotation toggles are shown. This makes for a better user-experience, showing less items at the same time.