### PR TITLE
Fix getSelection is not a function

### DIFF
--- a/packages/surface/Surface.js
+++ b/packages/surface/Surface.js
@@ -125,7 +125,7 @@ class Surface extends Component {
       }
       if (!this.isReadonly()) {
         // Mouse Events
-        el.on('mousedown', this.onMouseDown)
+        el.on('mousedown', this.onMouseDown.bind(this))
         el.on('contextmenu', this.onContextMenu)
         // disable drag'n'drop
         // we will react on this to render a custom selection


### PR DESCRIPTION
I often see following error
```
this.getSelection is not a function
    at ContainerEditor.onMouseDown
```

on this line https://github.com/podviaznikov/substance/blob/e28b9d6da97a83ffc844248072d34c4d3ade1b1e/packages/surface/Surface.js#L351

Adding binding to correct this.