### PR TITLE
Spreading arguments (surface) to super class

### DIFF
--- a/packages/scroll-pane/ScrollPane.js
+++ b/packages/scroll-pane/ScrollPane.js
@@ -227,7 +227,7 @@ class ScrollPane extends AbstractScrollPane {
     Determines the selection bounding rectangle relative to the scrollpane's content.
   */
   _onDomSelectionRendered() {
-    super._onDomSelectionRendered()
+    super._onDomSelectionRendered(...arguments)
     this._updateScrollbar()
   }
 


### PR DESCRIPTION
AbstractScrollPane._onDomSelectionRendered is expecting a surface as a argument. Pass it from Scrollpane