### PR TITLE
#997 Prevent annotation from expanding when typing "after" the annota…

### DIFF
--- a/model/Editing.js
+++ b/model/Editing.js
@@ -758,7 +758,8 @@ class Editing {
     III: |-<-->-|    :   delete anno
     IV: |-<-|->      :   move start by diff to start+L, and end by total span+L
     V: <-|->-|       :   move end by diff to start+L
-    VI: <-|--|->     :   move end by total span+L
+    VI: <-->|--|     :   noting if !anno.autoExpandRight
+    VII: <-|--|->    :   move end by total span+L
   */
   _insertText(tx, sel, text) {
     let start = sel.start
@@ -814,7 +815,11 @@ class Editing {
         // NOTE: here the anno gets expanded (that's the common way)
         tx.update([anno.id, 'end'], { type: 'shift', value: startOffset-annoEnd+L })
       }
-      // VI anno.start before and anno.end after
+      // VI
+      else if (annoEnd === startOffset && !anno.constructor.autoExpandRight) {
+          // skip
+      }
+      // VII anno.start before and anno.end after
       else if (annoStart<startOffset && annoEnd>=endOffset) {
         if (anno._isInlineNode) {
           // skip

--- a/model/PropertyAnnotation.js
+++ b/model/PropertyAnnotation.js
@@ -81,6 +81,7 @@ class PropertyAnnotation extends Annotation {
 }
 
 PropertyAnnotation.isPropertyAnnotation = true
+PropertyAnnotation.autoExpandRight = true
 PropertyAnnotation.prototype._isAnnotation = true
 PropertyAnnotation.prototype._isPropertyAnnotation = true
 


### PR DESCRIPTION
This is a proposal on how to solve issue #997 with auto expanding annotations.

What do you guys think? Is this good enough or could it be handled in a better way?