### PR TITLE
Added config option to force plain-text paste

### DIFF
--- a/packages/surface/Surface.js
+++ b/packages/surface/Surface.js
@@ -36,7 +36,8 @@ class Surface extends Component {
     this._surfaceId = createSurfaceId(this)
 
     this.clipboard = new Clipboard(this.editorSession, {
-      converterRegistry: this.context.converterRegistry
+      converterRegistry: this.context.converterRegistry,
+      editorOptions: this.editorSession.getConfigurator().getEditorOptions()
     })
 
     this.domSelection = this.context.domSelection

--- a/ui/Clipboard.js
+++ b/ui/Clipboard.js
@@ -30,10 +30,10 @@ class Clipboard {
     let _config = {
       schema: schema,
       DocumentClass: doc.constructor,
-      converters: htmlConverters
+      converters: htmlConverters,
+      editorOptions: config.editorOptions
     }
 
-    this.forcePlainTextPaste = Boolean(config.editorOptions['forcePlainTextPaste'])
     this.htmlImporter = new ClipboardImporter(_config)
     this.htmlExporter = new ClipboardExporter(_config)
   }
@@ -153,7 +153,7 @@ class Clipboard {
 
     // if we have content given as HTML we let the importer assess the quality first
     // and fallback to plain text import if it's bad
-    if (!this.forcePlainTextPaste && html) {
+    if (html) {
       if (!this._pasteHtml(html, plainText)) {
         this._pastePlainText(plainText)
       }

--- a/ui/Clipboard.js
+++ b/ui/Clipboard.js
@@ -33,6 +33,7 @@ class Clipboard {
       converters: htmlConverters
     }
 
+    this.forcePlainTextPaste = Boolean(config.editorOptions['forcePlainTextPaste'])
     this.htmlImporter = new ClipboardImporter(_config)
     this.htmlExporter = new ClipboardExporter(_config)
   }
@@ -152,7 +153,7 @@ class Clipboard {
 
     // if we have content given as HTML we let the importer assess the quality first
     // and fallback to plain text import if it's bad
-    if (html) {
+    if (!this.forcePlainTextPaste && html) {
       if (!this._pasteHtml(html, plainText)) {
         this._pastePlainText(plainText)
       }

--- a/ui/ClipboardImporter.js
+++ b/ui/ClipboardImporter.js
@@ -73,6 +73,10 @@ class ClipboardImporter extends HTMLImporter {
       }
     }
 
+    if (Boolean(config.editorOptions['forcePlainTextPaste'])) {
+      return null;
+    }
+
     el = DefaultDOMElement.parseHTML(html)
     if (isArray(el)) {
       body = this._createElement('body')

--- a/util/Configurator.js
+++ b/util/Configurator.js
@@ -73,7 +73,8 @@ class Configurator {
       icons: {},
       labels: {},
       lang: 'en_US',
-      SaveHandlerClass: null
+      SaveHandlerClass: null,
+      editorOptions: []
     }
   }
 
@@ -90,7 +91,23 @@ class Configurator {
     this.config.schema = schema
   }
 
-  /**
+  addEditorOption(option) {
+    if (!option.key) {
+      throw new Error('An option key must be defined')
+    }
+
+    if (!option.value) {
+      throw new Error('An option value must be defined')
+    }
+
+    this.config.editorOptions[option.key] = option.value;
+  }
+
+  getEditorOptions() {
+    return this.config.editorOptions;
+  }
+
+    /**
     Adds a node to this configuration. Later, when you use
     {@link Configurator#getSchema()}, this node will be added to that schema.
     Usually, used within a package to add its own nodes to the schema.
@@ -560,6 +577,7 @@ class Configurator {
     let SaveHandler = this.config.SaveHandlerClass || SaveHandlerStub
     return new SaveHandler()
   }
+
 }
 
 export default Configurator


### PR DESCRIPTION
When HTML is pasted, line breaks are removed and text styling is being applied in a non-controlled fashion. As a result this pull request introduces an option that an editor should allow for text-plain paste only.

At a later stage, perhaps the paste functionality should iterate through the pasted text and for each element convert the computedStyle to a document specific annotation.