### PR TITLE
Added config option to force plain-text paste

### DIFF
--- a/packages/surface/Surface.js
+++ b/packages/surface/Surface.js
@@ -36,7 +36,8 @@ class Surface extends Component {
     this._surfaceId = createSurfaceId(this)
 
     this.clipboard = new Clipboard(this.editorSession, {
-      converterRegistry: this.context.converterRegistry
+      converterRegistry: this.context.converterRegistry,
+      editorOptions: this.editorSession.getConfigurator().getEditorOptions()
     })
 
     this.domSelection = this.context.domSelection

--- a/ui/Clipboard.js
+++ b/ui/Clipboard.js
@@ -30,7 +30,8 @@ class Clipboard {
     let _config = {
       schema: schema,
       DocumentClass: doc.constructor,
-      converters: htmlConverters
+      converters: htmlConverters,
+      editorOptions: config.editorOptions
     }
 
     this.htmlImporter = new ClipboardImporter(_config)

--- a/ui/ClipboardImporter.js
+++ b/ui/ClipboardImporter.js
@@ -36,6 +36,9 @@ class ClipboardImporter extends HTMLImporter {
     this._isWindows = platform.isWindows
 
     this._emptyDoc = this._createDocument(this.schema)
+
+    this.editorOptions = config.editorOptions
+
   }
 
   dispose() {
@@ -71,6 +74,10 @@ class ClipboardImporter extends HTMLImporter {
           console.error(err)
         }
       }
+    }
+
+    if (this.editorOptions['forcePlainTextPaste']) {
+      return null;
     }
 
     el = DefaultDOMElement.parseHTML(html)

--- a/ui/ClipboardImporter.js
+++ b/ui/ClipboardImporter.js
@@ -76,7 +76,7 @@ class ClipboardImporter extends HTMLImporter {
       }
     }
 
-    if (this.editorOptions['forcePlainTextPaste']) {
+    if (this.editorOptions && this.editorOptions['forcePlainTextPaste']) {
       return null;
     }
 

--- a/util/Configurator.js
+++ b/util/Configurator.js
@@ -73,7 +73,8 @@ class Configurator {
       icons: {},
       labels: {},
       lang: 'en_US',
-      SaveHandlerClass: null
+      SaveHandlerClass: null,
+      editorOptions: []
     }
   }
 
@@ -90,7 +91,23 @@ class Configurator {
     this.config.schema = schema
   }
 
-  /**
+  addEditorOption(option) {
+    if (!option.key) {
+      throw new Error('An option key must be defined')
+    }
+
+    if (!option.value) {
+      throw new Error('An option value must be defined')
+    }
+
+    this.config.editorOptions[option.key] = option.value;
+  }
+
+  getEditorOptions() {
+    return this.config.editorOptions;
+  }
+
+    /**
     Adds a node to this configuration. Later, when you use
     {@link Configurator#getSchema()}, this node will be added to that schema.
     Usually, used within a package to add its own nodes to the schema.
@@ -560,6 +577,7 @@ class Configurator {
     let SaveHandler = this.config.SaveHandlerClass || SaveHandlerStub
     return new SaveHandler()
   }
+
 }
 
 export default Configurator


### PR DESCRIPTION
Pasting HTML gives unwanted results. This pull request enables editor sessions to be configured
to allow plain-text paste only, except for in-document copy-paste operations.