### PR TITLE
Added config option to force plain-text paste

### DIFF
--- a/ui/Clipboard.js
+++ b/ui/Clipboard.js
@@ -28,7 +28,8 @@ class Clipboard {
     let _config = {
       schema: schema,
       DocumentClass: doc.constructor,
-      converters: htmlConverters
+      converters: htmlConverters,
+      editorOptions: config.editorOptions
     }
 
     this.htmlImporter = new ClipboardImporter(_config)

--- a/ui/ClipboardImporter.js
+++ b/ui/ClipboardImporter.js
@@ -57,8 +57,8 @@ class ClipboardImporter extends HTMLImporter {
       }
     }
 
-    if (this.editorOptions['forcePlainTextPaste']) {
-      return null
+    if (this.editorOptions && this.editorOptions['forcePlainTextPaste']) {
+      return null;
     }
 
     let htmlDoc = DefaultDOMElement.parseHTML(html)

--- a/ui/ClipboardImporter.js
+++ b/ui/ClipboardImporter.js
@@ -25,6 +25,7 @@ class ClipboardImporter extends HTMLImporter {
     // ATTENTION: this is only here so we can enfore windows conversion
     // mode from within tests
     this._isWindows = platform.isWindows
+    this.editorOptions = config.editorOptions
   }
 
   /**
@@ -54,6 +55,10 @@ class ClipboardImporter extends HTMLImporter {
           // nothing
         }
       }
+    }
+
+    if (this.editorOptions['forcePlainTextPaste']) {
+      return null
     }
 
     let htmlDoc = DefaultDOMElement.parseHTML(html)

--- a/ui/Configurator.js
+++ b/ui/Configurator.js
@@ -69,7 +69,8 @@ class Configurator {
       icons: {},
       labels: {},
       lang: 'en_US',
-      SaveHandlerClass: null
+      SaveHandlerClass: null,
+      editorOptions: []
     }
   }
 
@@ -93,7 +94,23 @@ class Configurator {
     this.config.schema = schema
   }
 
-  /**
+  addEditorOption(option) {
+    if (!option.key) {
+      throw new Error('An option key must be defined')
+    }
+
+    if (!option.value) {
+      throw new Error('An option value must be defined')
+    }
+
+    this.config.editorOptions[option.key] = option.value;
+  }
+
+  getEditorOptions() {
+    return this.config.editorOptions;
+  }
+
+    /**
     Adds a node to this configuration. Later, when you use
     {@link Configurator#getSchema()}, this node will be added to that schema.
     Usually, used within a package to add its own nodes to the schema.
@@ -562,6 +579,7 @@ class Configurator {
     let SaveHandler = this.config.SaveHandlerClass || SaveHandlerStub
     return new SaveHandler()
   }
+
 }
 
 export default Configurator

--- a/ui/Surface.js
+++ b/ui/Surface.js
@@ -32,7 +32,8 @@ class Surface extends Component {
     this._surfaceId = createSurfaceId(this)
 
     this.clipboard = new Clipboard(this.editorSession, {
-      converterRegistry: this.context.converterRegistry
+      converterRegistry: this.context.converterRegistry,
+      editorOptions: this.editorSession.getConfigurator().getEditorOptions()
     })
 
     this.domSelection = this.context.domSelection


### PR DESCRIPTION
Pasting HTML gives unwanted results. This pull request enables editor sessions to be configured
to allow plain-text paste only, except for in-document copy-paste operations.

(This was #1019 before)