### PR TITLE
added support for h2, h3 and paragraph macro

### DIFF
--- a/packages/heading/HeadingMacro.js
+++ b/packages/heading/HeadingMacro.js
@@ -1,6 +1,6 @@
 export default {
 
-  appliesTo: ['paragraph'],
+  appliesTo: ['paragraph','heading'],
 
   execute: function(props) {
     if (this.appliesTo.indexOf(props.node.type) === -1) {
@@ -9,7 +9,7 @@ export default {
     if (props.action !== 'type') {
       return false
     }
-    let match = /^#\s/.exec(props.text)
+    let match = /^([#]{1,4})\s/.exec(props.text)
     if (match) {
       // console.log('Applying HeadingMacro')
       let editorSession = props.editorSession
@@ -24,10 +24,8 @@ export default {
           endOffset: match[0].length
         })
         tx.deleteSelection()
-        let node = tx.switchTextType({
-          type: 'heading',
-          level: 1
-        })
+        let newType = (match[1].length < 4 ? {type:'heading',level:match[1].length} : {type:'paragraph'})
+        let node = tx.switchTextType(newType)
         tx.setSelection({
           type: 'property',
           path: node.getTextPath(),


### PR DESCRIPTION
first jab at thinking at #736 (only for headings promoting + paragraph demoting, list and stuff comming up soon)
```
# => h1
## => h2
### => h3
#### => paragraph (is not a markdown spec, but there should be a way to demote to paragraph, isn't it?)
```

Do you prefer to put this in a different module, as this one might be used already in different project (and you don't want to change behavior of it) ?