### PR TITLE
Allowing for custom Manager implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Beta 7
 
+- `InsertNodeCommand` should be provided with `config.nodeType` (similar to AnnotationCommand). While old code should still work right now, this will probably break in future.
 - `editorSession.setSelection()` does not require explicit specification of
   `containerId` in most cases. Instead the information is derived from the
   surface if a `surfaceId` is given.

--- a/packages/image/ImagePackage.js
+++ b/packages/image/ImagePackage.js
@@ -14,6 +14,7 @@ export default {
     config.addConverter('html', ImageHTMLConverter)
     config.addConverter('xml', ImageHTMLConverter)
     config.addCommand('insert-image', InsertImageCommand, {
+      nodeType: 'image',
       commandGroup: 'insert'
     })
     config.addTool('insert-image', InsertImageTool)

--- a/packages/image/InsertImageCommand.js
+++ b/packages/image/InsertImageCommand.js
@@ -1,7 +1,7 @@
 import { InsertNodeCommand } from '../../ui'
 import insertImage from './insertImage'
 
-class ImageCommand extends InsertNodeCommand {
+export default class InsertImageCommand extends InsertNodeCommand {
 
   /*
     Inserts file and image nodes
@@ -17,5 +17,3 @@ class ImageCommand extends InsertNodeCommand {
   }
 
 }
-
-export default ImageCommand

--- a/ui/AnnotationCommand.js
+++ b/ui/AnnotationCommand.js
@@ -42,6 +42,10 @@ class AnnotationCommand extends Command {
     return this.config.nodeType
   }
 
+  getType() {
+    return this.getAnnotationType()
+  }
+
   /**
     Get the annotation's data.
 

--- a/ui/AnnotationCommand.js
+++ b/ui/AnnotationCommand.js
@@ -297,6 +297,10 @@ class AnnotationCommand extends Command {
     }
   }
 
+  isAnnotationCommand() {
+    return true
+  }
+
   _checkPrecondition(params, annos, checker) {
     let sel = this._getSelection(params)
     if (!checker.call(this, annos, sel)) {

--- a/ui/Command.js
+++ b/ui/Command.js
@@ -95,6 +95,27 @@ class Command {
     throw new Error('Command.execute() is abstract.')
   }
 
+  /*
+    @returns true if this command is creating or editing an annotation
+  */
+  isAnnotationCommand() {
+    return false
+  }
+
+  /*
+    @returns true if this command is inserting a node into a container
+  */
+  isInsertCommand() {
+    return false
+  }
+
+  /*
+    @returns true if this command is switching the type of a block-level text node
+  */
+  isSwitchTypeCommand() {
+    return false
+  }
+
   _getEditorSession(params, context) {
     let editorSession = params.editorSession || context.editorSession
     if (!editorSession) {

--- a/ui/Configurator.js
+++ b/ui/Configurator.js
@@ -1,9 +1,19 @@
 import { forEach, map, isString, Registry } from '../util'
 import { DocumentSchema, EditingBehavior } from '../model'
 import ComponentRegistry from './ComponentRegistry'
+
 import FontAwesomeIconProvider from './FontAwesomeIconProvider'
 import LabelProvider from './DefaultLabelProvider'
-import SaveHandlerStub from '../packages/persistence/SaveHandlerStub'
+
+import DefaultCommandManager from './CommandManager'
+import DefaultDragManager from './DragManager'
+import DefaultFileManager from './FileManager'
+import DefaultGlobalEventHandler from './GlobalEventHandler'
+import DefaultKeyboardManager from './KeyboardManager'
+import DefaultMacroManager from './MacroManager'
+import DefaultMarkersManager from './MarkersManager'
+import DefaultSurfaceManager from './SurfaceManager'
+import DefaultSaveHandler from '../packages/persistence/SaveHandlerStub'
 
 /**
   Default Configurator for Substance editors. It provides an API for
@@ -69,8 +79,10 @@ class Configurator {
       icons: {},
       labels: {},
       lang: 'en_US',
+      editorOptions: [],
+      CommandManagerClass: DefaultCommandManager,
+      DragManagerClass: DefaultDragManager,
       SaveHandlerClass: null,
-      editorOptions: []
     }
   }
 
@@ -555,14 +567,81 @@ class Configurator {
     return this.config.lang || 'en_US'
   }
 
+  /* This is used for DependencyInjection of core implementations */
+
+  setCommandManagerClass(CommandManagerClass) {
+    this.config.CommandManagerClass = CommandManagerClass
+  }
+
+  getCommandManagerClass() {
+    return this.config.CommandManagerClass || DefaultCommandManager
+  }
+
+  setDragManagerClass(DragManagerClass) {
+    this.config.DragManagerClass = DragManagerClass
+  }
+
+  getDragManagerClass() {
+    return this.config.DragManagerClass || DefaultDragManager
+  }
+
+  setFileManagerClass(FileManagerClass) {
+    this.config.FileManagerClass = FileManagerClass
+  }
+
+  getFileManagerClass() {
+    return this.config.FileManagerClass || DefaultFileManager
+  }
+
+  setGlobalEventHandlerClass(GlobalEventHandlerClass) {
+    this.config.GlobalEventHandlerClass = GlobalEventHandlerClass
+  }
+
+  getGlobalEventHandlerClass() {
+    return this.config.GlobalEventHandlerClass || DefaultGlobalEventHandler
+  }
+
+  setKeyboardManagerClass(KeyboardManagerClass) {
+    this.config.KeyboardManagerClass = KeyboardManagerClass
+  }
+
+  getKeyboardManagerClass() {
+    return this.config.KeyboardManagerClass || DefaultKeyboardManager
+  }
+
+  setMacroManagerClass(MacroManagerClass) {
+    this.config.MacroManagerClass = MacroManagerClass
+  }
+
+  getMacroManagerClass() {
+    return this.config.MacroManagerClass || DefaultMacroManager
+  }
+
+  setMarkersManagerClass(MarkersManagerClass) {
+    this.config.MarkersManagerClass = MarkersManagerClass
+  }
+
+  getMarkersManagerClass() {
+    return this.config.MarkersManagerClass || DefaultMarkersManager
+  }
+
+  setSurfaceManagerClass(SurfaceManagerClass) {
+    this.config.SurfaceManagerClass = SurfaceManagerClass
+  }
+
+  getSurfaceManagerClass() {
+    return this.config.SurfaceManagerClass || DefaultSurfaceManager
+  }
+
   setSaveHandlerClass(SaveHandlerClass) {
     this.config.SaveHandlerClass = SaveHandlerClass
   }
 
   getSaveHandler() {
-    let SaveHandler = this.config.SaveHandlerClass || SaveHandlerStub
+    let SaveHandler = this.config.SaveHandlerClass || DefaultSaveHandler
     return new SaveHandler()
   }
+
 
 }
 

--- a/ui/EditorSession.js
+++ b/ui/EditorSession.js
@@ -1,14 +1,6 @@
 import { forEach, isPlainObject, isFunction, isString, EventEmitter } from '../util'
 import { Selection, SelectionState, ChangeHistory,
   Transaction, operationHelpers } from '../model'
-import CommandManager from './CommandManager'
-import DragManager from './DragManager'
-import FileManager from './FileManager'
-import GlobalEventHandler from './GlobalEventHandler'
-import KeyboardManager from './KeyboardManager'
-import MacroManager from './MacroManager'
-import MarkersManager from './MarkersManager'
-import SurfaceManager from './SurfaceManager'
 
 class EditorSession extends EventEmitter {
 
@@ -18,10 +10,11 @@ class EditorSession extends EventEmitter {
     options = options || {}
 
     this.document = doc
-    if (!options.configurator) {
+    const configurator = options.configurator
+    if (!configurator) {
       throw new Error('No configurator provided.')
     }
-    this.configurator = options.configurator
+    this.configurator = configurator
 
     this._transaction = new Transaction(doc)
     // HACK: we want `tx.setSelection()` to add surfaceId to the selection
@@ -58,6 +51,15 @@ class EditorSession extends EventEmitter {
 
     // Managers
     // --------
+    const CommandManager = configurator.getCommandManagerClass()
+    const DragManager = configurator.getDragManagerClass()
+    const FileManager = configurator.getFileManagerClass()
+    const GlobalEventHandler = configurator.getGlobalEventHandlerClass()
+    const KeyboardManager = configurator.getKeyboardManagerClass()
+    const MacroManager = configurator.getMacroManagerClass()
+    const MarkersManager = configurator.getMarkersManagerClass()
+    const SurfaceManager = configurator.getSurfaceManagerClass()
+
 
     // surface manager takes care of surfaces, keeps track of the currently focused surface
     // and makes sure the DOM selection is rendered properly at the end of a flow
@@ -73,7 +75,6 @@ class EditorSession extends EventEmitter {
       Object.assign(this._context, options.context)
     }
 
-    let configurator = this.configurator
     let commands = configurator.getCommands()
     let dropHandlers = configurator.getDropHandlers()
     let macros = configurator.getMacros()

--- a/ui/InlineNodeComponent.js
+++ b/ui/InlineNodeComponent.js
@@ -101,7 +101,7 @@ class InlineNodeComponent extends AbstractIsolatedNodeComponent {
     if (surface === this.context.surface) {
       let sel = selState.getSelection()
       let node = this.props.node
-      if (sel.isPropertySelection() && !sel.isCollapsed() && isEqual(sel.path, node.path)) {
+      if (sel.isPropertySelection() && !sel.isCollapsed() && isEqual(sel.start.path, node.start.path)) {
         let nodeSel = node.getSelection()
         if(nodeSel.equals(sel)) {
           return { mode: 'selected' }

--- a/ui/InsertNodeCommand.js
+++ b/ui/InsertNodeCommand.js
@@ -3,6 +3,21 @@ import Command from './Command'
 
 class InsertNodeCommand extends Command {
 
+  constructor(config) {
+    super(config)
+
+    // Note: we want to know about the node which this command is producing
+    // For example we will inhibit commands, that produce a node type
+    // not allowed in the current position
+    if (!this.config.nodeType) {
+      console.error("'config.nodeType' should be provided for InsertNodeCommand")
+    }
+  }
+
+  getType() {
+    return this.config.nodeType
+  }
+
   getCommandState(params) {
     let sel = params.selection
     let newState = {

--- a/ui/SwitchTextTypeCommand.js
+++ b/ui/SwitchTextTypeCommand.js
@@ -54,6 +54,11 @@ class SwitchTextTypeCommand extends Command {
       return tx.switchTextType(this.config.spec)
     })
   }
+
+  isSwitchTypeCommand() {
+    return true
+  }
+
 }
 
 export default SwitchTextTypeCommand

--- a/ui/SwitchTextTypeCommand.js
+++ b/ui/SwitchTextTypeCommand.js
@@ -12,6 +12,20 @@ import { Command } from '.'
 */
 class SwitchTextTypeCommand extends Command {
 
+  constructor(config) {
+    super(config)
+    if (!config.spec) {
+      throw new Error("'config.spec' is mandatory")
+    }
+    if (!config.spec.type) {
+      throw new Error("'config.spec.type' is mandatory")
+    }
+  }
+
+  getType() {
+    return this.config.spec.type
+  }
+
   getCommandState(params) {
     let doc = params.editorSession.getDocument()
     let sel = params.selection

--- a/ui/ToolGroup.js
+++ b/ui/ToolGroup.js
@@ -73,7 +73,7 @@ class ToolGroup extends Component {
     We map an array of command groups to array command states
   */
   _getCommandStates() {
-    let commandStates = this.context.commandManager.getCommandStates()
+    let commandStates = this.context.editorSession.getCommandStates()
     let commandGroups = this.context.commandGroups
     let filteredCommandStates = {} // command states objects of that group
     this.props.commandGroups.forEach((commandGroup) => {

--- a/ui/ToolPanel.js
+++ b/ui/ToolPanel.js
@@ -61,7 +61,7 @@ class ToolPanel extends Component {
   }
 
   _getCommandStates() {
-    return this.context.commandManager.getCommandStates()
+    return this.context.editorSession.getCommandStates()
   }
 
 }

--- a/xml/SchemaDrivenCommandManager.js
+++ b/xml/SchemaDrivenCommandManager.js
@@ -43,7 +43,6 @@ export default class SchemaDrivenCommandManager extends CommandManager {
     const doc = editorSession.getDocument()
     const selectionState = params.selectionState
     const sel = params.selection
-    const surface = params.surface
     const isBlurred = params.editorSession.isBlurred()
     const noSelection = !sel || sel.isNull() || !sel.isAttached()
 
@@ -67,34 +66,36 @@ export default class SchemaDrivenCommandManager extends CommandManager {
       }
 
       const isInsideText = node.isText()
-      const isBlockNode = node.isBlock()
       const xmlSchema = doc.getXMLSchema()
-      const elementSchema = xmlSchema.getElementSchema(node.type)
 
       // annotations can only be applied on PropertySelections inside
       // text, and not on an inline-node
       if (isInsideText && sel.isPropertySelection() && !selectionState.isInlineNodeSelection()) {
+        const elementSchema = xmlSchema.getElementSchema(node.type)
         _evaluateTyped(this.annotationCommands, elementSchema)
       } else {
         _disable(this.annotationCommands)
       }
 
       // for InsertCommands the selection must be inside a ContainerEditor
-      if (!surface || !surface.isContainerEditor()) {
+      let parentNode = node.parentNode
+      if (!parentNode || !parentNode.isContainer()) {
         _disable(this.insertCommands)
       } else {
         // TODO: disable all commands with types that are not allowed
         // at the current position
+        const elementSchema = xmlSchema.getElementSchema(parentNode.type)
         _evaluateTyped(this.insertCommands, elementSchema)
       }
 
       // SwitchTypeCommands can only be applied to
       // block-level text nodes
-      if (!sel.containerId || !isInsideText || !isBlockNode) {
+      if (!sel.containerId || !isInsideText || !parentNode.isContainer()) {
         _disable(this.switchTypeCommands)
       } else {
         // TODO: disable all commands with types that are not allowed
         // at the current position
+        const elementSchema = xmlSchema.getElementSchema(parentNode.type)
         _evaluateTyped(this.switchTypeCommands, elementSchema)
       }
     }

--- a/xml/SchemaDrivenCommandManager.js
+++ b/xml/SchemaDrivenCommandManager.js
@@ -1,0 +1,137 @@
+import { CommandManager } from '../ui'
+
+const DISABLED = Object.freeze({
+  disabled: true
+})
+
+/*
+  Experimental CommandManager that makes use of the XML schema
+  to inhibit commands which are not allowed at the current position.
+*/
+export default class SchemaDrivenCommandManager extends CommandManager {
+
+  _initialize() {
+    const annotationCommands = new Map()
+    const insertCommands = new Map()
+    const switchTypeCommands = new Map()
+    const otherCommands = new Map()
+    this.commands.forEach((command) => {
+      const name = command.getName()
+      if (command.isAnnotationCommand()) {
+        annotationCommands.set(name, command)
+      } else if (command.isInsertCommand()) {
+        insertCommands.set(name, command)
+      } else if (command.isSwitchTypeCommand()) {
+        switchTypeCommands.set(name, command)
+      } else {
+        otherCommands.set(name, command)
+      }
+    })
+    this.annotationCommands = annotationCommands
+    this.insertCommands = insertCommands
+    this.switchTypeCommands = switchTypeCommands
+    this.otherCommands = otherCommands
+  }
+
+  _updateCommandStates(editorSession) {
+    const commandStates = {}
+    const annotationCommands = this.annotationCommands
+    const insertCommands = this.insertCommands
+    const switchTypeCommands = this.switchTypeCommands
+    const commandContext = this._getCommandContext()
+    const params = this._getCommandParams()
+    const doc = editorSession.getDocument()
+    const selectionState = params.selectionState
+    const sel = params.selection
+    const surface = params.surface
+    const isBlurred = params.editorSession.isBlurred()
+    const noSelection = !sel || sel.isNull() || !sel.isAttached()
+
+    // all editing commands are disabled if
+    // - this editorSession is blurred,
+    // - or the selection is null,
+    // - or the selection is inside a custom editor
+    if (isBlurred || noSelection || sel.isCustomSelection()) {
+      _disableEditingCommands()
+    } else {
+      const path = sel.start.path
+      const node = doc.get(path[0])
+
+      // TODO: is this really necessary. It rather seems to be
+      // a workaround for other errors, i.e., the selection pointing
+      // to a non existing node
+      // If really needed we should document why, and in which case.
+      if (!node) {
+        // FIXME: explain when this happens.'
+        throw new Error('FIXME: explain when this happens')
+      }
+
+      const isInsideText = node.isText()
+      const isBlockNode = node.isBlock()
+      const xmlSchema = doc.getXMLSchema()
+      const elementSchema = xmlSchema.getElementSchema(node.type)
+
+      // annotations can only be applied on PropertySelections inside
+      // text, and not on an inline-node
+      if (isInsideText && sel.isPropertySelection() && !selectionState.isInlineNodeSelection()) {
+        _evaluateTyped(this.annotationCommands, elementSchema)
+      } else {
+        _disable(this.annotationCommands)
+      }
+
+      // for InsertCommands the selection must be inside a ContainerEditor
+      if (!surface || !surface.isContainerEditor()) {
+        _disable(this.insertCommands)
+      } else {
+        // TODO: disable all commands with types that are not allowed
+        // at the current position
+        _evaluateTyped(this.insertCommands, elementSchema)
+      }
+
+      // SwitchTypeCommands can only be applied to
+      // block-level text nodes
+      if (!sel.containerId || !isInsideText || !isBlockNode) {
+        _disable(this.switchTypeCommands)
+      } else {
+        // TODO: disable all commands with types that are not allowed
+        // at the current position
+        _evaluateTyped(this.switchTypeCommands, elementSchema)
+      }
+    }
+
+    // other commands must check their own preconditions
+    _evaluateUntyped(this.otherCommands)
+
+    // ATTENTION: this does not reflow. We should refactor EditorSession
+    // and make it more consistent
+    editorSession.setCommandStates(commandStates)
+
+    function _disableEditingCommands() {
+      _disable(annotationCommands)
+      _disable(insertCommands)
+      _disable(switchTypeCommands)
+    }
+
+    function _disable(commands) {
+      commands.forEach((cmd, name) => {
+        commandStates[name] = DISABLED
+      })
+    }
+    function _evaluateTyped(commands, elementSchema) {
+      commands.forEach((cmd, name) => {
+        const type = cmd.getType()
+        if (elementSchema.isAllowed(type)) {
+          commandStates[name] = cmd.getCommandState(params, commandContext)
+        } else {
+          commandStates[name] = DISABLED
+        }
+      })
+    }
+    function _evaluateUntyped(commands) {
+      commands.forEach((cmd, name) => {
+        commandStates[name] = cmd.getCommandState(params, commandContext)
+      })
+    }
+
+  }
+}

--- a/xml/XMLContainerNode.js
+++ b/xml/XMLContainerNode.js
@@ -11,6 +11,10 @@ export default class XMLContainerNode extends ContainerMixin(XMLElementNode) {
     return this.childNodes
   }
 
+  isContainer() {
+    return true
+  }
+
 }
 
 XMLContainerNode.prototype._elementType = 'container'

--- a/xml/XMLSchema.js
+++ b/xml/XMLSchema.js
@@ -1,7 +1,15 @@
+import { forEach } from '../util'
+import DFA from './DFA'
+
+const { TEXT, EPSILON } = DFA
+
 export default class XMLSchema {
 
   constructor(elementSchemas) {
-    this._elementSchemas = elementSchemas
+    this._elementSchemas = {}
+    forEach(elementSchemas, (spec, name) => {
+      this._elementSchemas[name] = new ElementSchema(spec)
+    })
   }
 
   getTagNames() {
@@ -11,4 +19,39 @@ export default class XMLSchema {
   getElementSchema(name) {
     return this._elementSchemas[name]
   }
+}
+
+class ElementSchema {
+
+  constructor({name, type, attributes, dfa}) {
+    this.name = name
+    this.type = type
+    this.attributes = attributes
+    this.dfa = dfa
+
+    this._initialize()
+  }
+
+  // EXPERIMENTAL: reflection API which is used
+  // to inhibit commands considering the current
+  // selection state
+  // This works only for ContainerNodes and TextNodes
+  // where order on the children is not restricted
+
+  _initialize() {
+    // Note: collecting all children
+    const children = {}
+    forEach(this.dfa.transitions, (T) => {
+      Object.keys(T).forEach((tagName) => {
+        if (tagName === TEXT || tagName === EPSILON) return
+        children[tagName] = true
+      })
+    })
+    this._allowedChildren = children
+  }
+
+  isAllowed(tagName) {
+    return Boolean(this._allowedChildren[tagName])
+  }
+
 }

--- a/xml/index.js
+++ b/xml/index.js
@@ -17,6 +17,7 @@ import compileRNG from './compileRNG'
 import deserializeXMLSchema from './deserializeXMLSchema'
 import serializeXMLSchema from './serializeXMLSchema'
 import registerSchema from './registerSchema'
+import SchemaDrivenCommandManager from './SchemaDrivenCommandManager'
 
 export {
   XMLAnchorNode,
@@ -37,5 +38,6 @@ export {
   serializeXMLSchema,
   deserializeXMLSchema,
   compileRNG,
-  registerSchema
+  registerSchema,
+  SchemaDrivenCommandManager
 }


### PR DESCRIPTION
For example, EditorSession uses a CommandManager. Via Configurator, the default class can be replaced now.

Plus:
- introduced command categories (`isAnnotationCommand(), isInsertCommand, isSwitchTypeCommand()`)
- introduced `elementSchema.isAllowed(tagName)` for schema reflection driven implementations.