### PR TITLE
Surface.focus()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   Use either `Container.show(nodeId)` or `Container.showAt(pos, nodeId)`
 - `el.appendChild(null)` does not throw
 - `el.insertBefore(child, null)` is equivalent to `el.appendChild(child)`
+- `surface.focus()` now behaves similar to a HTML input element, i.e. setting the cursor to the first position
 
 These changes might break your current implementation and may need some migration:
 

--- a/packages/scroll-pane/ScrollPane.js
+++ b/packages/scroll-pane/ScrollPane.js
@@ -218,7 +218,7 @@ class ScrollPane extends AbstractScrollPane {
         this.setScrollPosition(offset)
       }
     } else {
-      console.warn('No match found for selector in scrollable container')
+      console.warn(`No match found for selector '${selector}' in scrollable container`)
     }
   }
 

--- a/ui/ContainerEditor.js
+++ b/ui/ContainerEditor.js
@@ -104,6 +104,15 @@ class ContainerEditor extends Surface {
     return el
   }
 
+  selectFirst() {
+    const container = this.getContainer()
+    if (container.getLength() > 0) {
+      const editorSession = this.getEditorSession()
+      const first = container.getChildAt(0)
+      selectionHelpers.setCursor(editorSession, first, container.id, 'before')
+    }
+  }
+
   _renderNode($$, node) {
     if (!node) throw new Error('Illegal argument')
     if (node.isText()) {

--- a/ui/Surface.js
+++ b/ui/Surface.js
@@ -203,22 +203,20 @@ class Surface extends Component {
     return null
   }
 
-  blur() {
-    if (this.el) {
-      this.el.blur()
+  focus() {
+    if (this.editorSession.getFocusedSurface() !== this) {
+      this.selectFirst()
     }
   }
 
-  focus() {
-    if (this.isDisabled()) return
-    // console.log('Focusing surface %s explicitly with Surface.focus()', this.getId());
-    // NOTE: FF is causing problems with dynamically activated contenteditables
-    // and focusing
-    if (platform.isFF) {
-      this.domSelection.clear()
-      this.el.getNativeElement().blur()
+  blur() {
+    if (this.editorSession.getFocusedSurface() === this) {
+      this.editorSession.setSelection(null)
     }
-    this._focus()
+  }
+
+  selectFirst() {
+    throw new Error('This method is abstract.')
   }
 
   // As the DOMSelection is owned by the Editor now, rerendering could now be done by someone else, e.g. the SurfaceManager?
@@ -496,7 +494,25 @@ class Surface extends Component {
     }
   }
 
+  _blur() {
+    if (this.el) {
+      this.el.blur()
+    }
+  }
+
   _focus() {
+    if (this.isDisabled()) return
+    // console.log('Focusing surface %s explicitly with Surface.focus()', this.getId());
+    // NOTE: FF is causing problems with dynamically activated contenteditables
+    // and focusing
+    if (platform.isFF) {
+      this.domSelection.clear()
+      this.el.getNativeElement().blur()
+    }
+    this._focusElement()
+  }
+
+  _focusElement() {
     this._state.hasNativeFocus = true
     // HACK: we must not focus explicitly in Chrome/Safari
     // as otherwise we get a crazy auto-scroll
@@ -606,7 +622,7 @@ class Surface extends Component {
     // until the next native blur.
     // TODO: check if this is still necessary
     if (!sel.isNull() && sel.surfaceId === this.id && platform.isFF) {
-      this._focus()
+      this._focusElement()
     }
     this.editorSession.setSelection(sel)
   }

--- a/ui/SurfaceManager.js
+++ b/ui/SurfaceManager.js
@@ -103,7 +103,7 @@ class SurfaceManager {
     let focusedSurface = this.getFocusedSurface()
     if (focusedSurface && !focusedSurface.isDisabled()) {
       // console.log('Rendering selection on surface', focusedSurface.getId(), this.editorSession.getSelection().toString());
-      focusedSurface.focus()
+      focusedSurface._focus()
       focusedSurface.rerenderDOMSelection()
     }
   }

--- a/ui/TextPropertyEditor.js
+++ b/ui/TextPropertyEditor.js
@@ -61,6 +61,15 @@ class TextPropertyEditor extends Surface {
     return el
   }
 
+  selectFirst() {
+    this.editorSession.setSelection({
+      type: "property",
+      path: this.getPath(),
+      startOffset: 0,
+      surfaceId: this.id
+    })
+  }
+
   _handleEnterKey(event) {
     event.preventDefault()
     event.stopPropagation()


### PR DESCRIPTION
This helper works like InputElement.focus(), setting the cursor at the first position.