### PR TITLE
Command states active with Surface.props.command

### DIFF
--- a/ui/CommandManager.js
+++ b/ui/CommandManager.js
@@ -115,6 +115,7 @@ export default class CommandManager {
           if (commandRegistry.contains(name)){
             return name
           }
+          return null
         })
       } else if (excluded) {
         commandNames = without(commandNames, ...excluded)

--- a/ui/CommandManager.js
+++ b/ui/CommandManager.js
@@ -112,7 +112,9 @@ export default class CommandManager {
       let excluded = surface.props.excludedCommands
       if (included) {
         commandNames = included.map((name) => {
-          return commandRegistry.contains(name)
+          if (commandRegistry.contains(name)){
+            return name
+          }
         })
       } else if (excluded) {
         commandNames = without(commandNames, ...excluded)


### PR DESCRIPTION
Change the include.map to return the name, not true or false, thus enabling toggle buttons on surfaces with surface.props.commands