### PR TITLE
Fix command state updating.

### DIFF
--- a/ui/CommandManager.js
+++ b/ui/CommandManager.js
@@ -111,7 +111,7 @@ export default class CommandManager {
       let included = surface.props.commands
       let excluded = surface.props.excludedCommands
       if (included) {
-        commandNames = included.map((name) => {
+        commandNames = included.filter((name) => {
           return commandRegistry.contains(name)
         })
       } else if (excluded) {


### PR DESCRIPTION
With #1078 you’ve introduced serious regression, a lot of commands not working at all (at least select all, undo, redo), but I believe that all of them was broken.
I think that you wanted to do a filtering of white-lists commands, but instead did a wrong thing.
Would be good to create a test case to prevent this kind of mistakes in future.