### PR TITLE
Align LinkTool buttons in the center

### DIFF
--- a/packages/link/_edit-link-tool.css
+++ b/packages/link/_edit-link-tool.css
@@ -1,5 +1,6 @@
 .sc-edit-link-tool {
   display: flex;
+  align-items: center;
 }
 
 .sc-edit-link-tool > * {


### PR DESCRIPTION
Fixes https://github.com/substance/substance/issues/1074