### PR TITLE
ES5 transpiler.

### DIFF
--- a/make.js
+++ b/make.js
@@ -95,7 +95,7 @@ function buildLib(target, production) {
       ]
     }
   }
-  if (target === 'legacy') {
+  if (target === 'browser:legacy') {
     config.buble = true
   }
   if (production) {


### PR DESCRIPTION
Fix for ES5 transpiling. As I mentioned in #1121 we also need to include some polyfills. At least for `Object.assign()` and `Array.from()`. Maybe it’s better to do that via Substance Bundler, for instance with special option `polyfills`.
Still we need to take a closer look at results of Buble compiler. I have a feeling that something goes wrong there which could be true, as [it is not working with all features](https://buble.surge.sh/guide/#unsupported-features).