### PR TITLE
Customizable label providers

### DIFF
--- a/dar/DocumentArchive.js
+++ b/dar/DocumentArchive.js
@@ -1,8 +1,17 @@
 export default class DocumentArchive {
 
-  constructor(sessions) {
+  constructor(sessions, buffer) {
     this.sessions = sessions
+    this.buffer = buffer
+
     if (!sessions.manifest) throw new Error("'manifest' session is required.")
+
+    this.init()
+  }
+
+  init() {
+    // register listeners for every session
+
   }
 
   getManifest() {
@@ -25,4 +34,6 @@ export default class DocumentArchive {
   getEditorSession(docId) {
     return this.sessions[docId]
   }
+
+
 }

--- a/test/LabelProvider.test.js
+++ b/test/LabelProvider.test.js
@@ -1,0 +1,134 @@
+import { module } from 'substance-test'
+import {
+  Configurator, EditorSession, Document, DocumentSchema, AbstractEditor, forEach
+} from 'substance'
+import getMountPoint from './fixture/getMountPoint'
+
+const test = module('LabelProvider')
+
+test('get label', (t) => {
+  let configurator = _simple()
+  let editorSession = _createEditorSession(configurator)
+  let editor = Editor1.mount({ editorSession }, getMountPoint(t))
+  let el = editor.getElement()
+  let fox = el.find('.fox')
+  t.equal(fox.textContent, 'Fox', 'label should have been provided')
+  t.end()
+})
+
+test('get translated label', (t) => {
+  let configurator = _simple()
+  let editorSession = _createEditorSession(configurator)
+  editorSession.setLanguage('de')
+  let editor = Editor1.mount({ editorSession }, getMountPoint(t))
+  let el = editor.getElement()
+  let fox = el.find('.fox')
+  t.equal(fox.textContent, 'Fuchs', 'translated label should have been provided')
+  t.end()
+})
+
+test('expand label with vars', (t) => {
+  let configurator = _items()
+  let editorSession = _createEditorSession(configurator)
+  let editor = Editor2.mount({ editorSession }, getMountPoint(t))
+  let el = editor.getElement()
+  let msg = el.find('.msg')
+  t.equal(msg.textContent, '5 items found', 'label should have been expanded')
+  t.end()
+})
+
+test('custom label provider', (t) => {
+  let configurator = _custom()
+  let editorSession = _createEditorSession(configurator)
+  let editor = Editor2.mount({ editorSession }, getMountPoint(t))
+  let el = editor.getElement()
+  let msg = el.find('.msg')
+  t.equal(msg.textContent, 'n_items_found@n=5@en', 'custom label should have been provided')
+  t.end()
+})
+
+test('switch language', (t) => {
+  let configurator = _simple()
+  let editorSession = _createEditorSession(configurator)
+  let editor = Editor1.mount({ editorSession }, getMountPoint(t))
+  let el = editor.getElement()
+  let fox = el.find('.fox')
+  t.equal(fox.textContent, 'Fox', 'label should have been provided')
+  // this should trigger a rerender on Editor
+  editorSession.setLanguage('de')
+  t.equal(fox.textContent, 'Fuchs', 'translated label should have been provided')
+  t.end()
+})
+
+function _simple() {
+  let config = new Configurator()
+  config.addLabel('fox', {
+    en: 'Fox',
+    de: 'Fuchs'
+  })
+  return config
+}
+
+function _items() {
+  let config = new Configurator()
+  config.addLabel('n_items_found', {
+    en: '${n} items found'
+  })
+  return config
+}
+
+function _custom() {
+  let config = new Configurator()
+  config.setLabelProviderClass(CustomLabelProvider)
+  config.addLabel('fox', {
+    en: 'Fox',
+    de: 'Fuchs'
+  })
+  return config
+}
+
+function _createEditorSession(configurator) {
+  let schema = new DocumentSchema({ name: 'stub', version: '1', DocumentClass: Document })
+  let doc = new Document(schema)
+  let editorSession = new EditorSession(doc, { configurator })
+  return editorSession
+}
+
+class Editor1 extends AbstractEditor {
+  render($$) {
+    return $$('div').append(
+      $$('div').addClass('fox').text(this.getLabel('fox')).ref('label')
+    )
+  }
+}
+
+class Editor2 extends AbstractEditor {
+  render($$) {
+    return $$('div').append(
+      $$('div').addClass('msg').text(this.getLabel('n_items_found', { n: 5 })).ref('label')
+    )
+  }
+}
+
+
+// just for demonstration
+class CustomLabelProvider {
+
+  constructor(labels, lang) {
+    this.lang = lang || 'en'
+    this.labels = labels
+  }
+
+  getLabel(name, params) {
+    let parts = [name]
+    forEach(params, (val, key) => {
+      parts.push(key+'='+val)
+    })
+    parts.push(this.lang)
+    return parts.join('@')
+  }
+
+  setLanguage(lang) {
+    this.lang = lang || 'en'
+  }
+}

--- a/ui/AbstractEditor.js
+++ b/ui/AbstractEditor.js
@@ -59,6 +59,13 @@ export default class AbstractEditor extends Component {
 
     this.resourceManager = new ResourceManager(this.editorSession, this.getChildContext())
     this.domSelection = new DOMSelection(this)
+
+    // if the language is changed update the LabelProvider
+    // and do a force rerender
+    this.editorSession.onUpdate('lang', (lang) => {
+      this.labelProvider.setLanguage(lang)
+    }, this)
+    this.editorSession.onRender('lang', this.rerender, this)
   }
 
   willReceiveProps(nextProps) {
@@ -71,7 +78,9 @@ export default class AbstractEditor extends Component {
   }
 
   _dispose() {
-    this.getEditorSession().detachEditor(this)
+    const editorSession = this.getEditorSession()
+    editorSession.off(this)
+    editorSession.detachEditor(this)
     // Note: we need to clear everything, as the childContext
     // changes which is immutable
     this.empty()

--- a/ui/AbstractEditor.js
+++ b/ui/AbstractEditor.js
@@ -144,4 +144,8 @@ export default class AbstractEditor extends Component {
     return this.surfaceManager
   }
 
+  getLabelProvider() {
+    return this.labelProvider
+  }
+
 }

--- a/ui/AbstractEditor.js
+++ b/ui/AbstractEditor.js
@@ -33,13 +33,14 @@ export default class AbstractEditor extends Component {
   }
 
   _initialize(props) {
-    if (!props.editorSession) {
+    const editorSession = props.editorSession
+    if (!editorSession) {
       throw new Error('EditorSession instance required');
     }
-    this.editorSession = props.editorSession
-    this.doc = this.editorSession.getDocument()
+    this.editorSession = editorSession
+    this.doc = editorSession.getDocument()
 
-    let configurator = this.editorSession.getConfigurator()
+    let configurator = editorSession.getConfigurator()
     this.componentRegistry = configurator.getComponentRegistry()
     this.commandGroups = configurator.getCommandGroups()
     this.keyboardShortcuts = configurator.getKeyboardShortcutsByCommand()
@@ -48,24 +49,26 @@ export default class AbstractEditor extends Component {
     this.iconProvider = configurator.getIconProvider()
 
     // legacy
-    this.surfaceManager = this.editorSession.surfaceManager
-    this.commandManager = this.editorSession.commandManager
-    this.dragManager = this.editorSession.dragManager
-    this.macroManager = this.editorSession.macroManager
-    this.converterRegistry = this.editorSession.converterRegistry
-    this.globalEventHandler = this.editorSession.globalEventHandler
-    this.editingBehavior = this.editorSession.editingBehavior
-    this.markersManager = this.editorSession.markersManager
+    this.surfaceManager = editorSession.surfaceManager
+    this.commandManager = editorSession.commandManager
+    this.dragManager = editorSession.dragManager
+    this.macroManager = editorSession.macroManager
+    this.converterRegistry = editorSession.converterRegistry
+    this.globalEventHandler = editorSession.globalEventHandler
+    this.editingBehavior = editorSession.editingBehavior
+    this.markersManager = editorSession.markersManager
 
-    this.resourceManager = new ResourceManager(this.editorSession, this.getChildContext())
+    this.resourceManager = new ResourceManager(editorSession, this.getChildContext())
     this.domSelection = new DOMSelection(this)
 
+    // initialize the label provider
+    this.labelProvider.setLanguage(editorSession.getLanguage())
     // if the language is changed update the LabelProvider
     // and do a force rerender
-    this.editorSession.onUpdate('lang', (lang) => {
+    editorSession.onUpdate('lang', (lang) => {
       this.labelProvider.setLanguage(lang)
     }, this)
-    this.editorSession.onRender('lang', this.rerender, this)
+    editorSession.onRender('lang', this.rerender, this)
   }
 
   willReceiveProps(nextProps) {

--- a/ui/Component.js
+++ b/ui/Component.js
@@ -256,9 +256,13 @@ class Component extends EventEmitter {
     ```
   */
   getLabel(name, ...args) {
-    let labelProvider = this.context.labelProvider
+    let labelProvider = this.getLabelProvider()
     if (!labelProvider) throw new Error('Missing labelProvider.')
     return labelProvider.getLabel(name, ...args)
+  }
+
+  getLabelProvider() {
+    return this.context.labelProvider
   }
 
   /**

--- a/ui/Component.js
+++ b/ui/Component.js
@@ -255,10 +255,10 @@ class Component extends EventEmitter {
     }
     ```
   */
-  getLabel(name) {
+  getLabel(name, ...args) {
     let labelProvider = this.context.labelProvider
     if (!labelProvider) throw new Error('Missing labelProvider.')
-    return labelProvider.getLabel(name)
+    return labelProvider.getLabel(name, ...args)
   }
 
   /**

--- a/ui/Configurator.js
+++ b/ui/Configurator.js
@@ -8,7 +8,6 @@ import EditingBehavior from '../model/EditingBehavior'
 import ComponentRegistry from './ComponentRegistry'
 
 import FontAwesomeIconProvider from './FontAwesomeIconProvider'
-import LabelProvider from './DefaultLabelProvider'
 
 import DefaultCommandManager from './CommandManager'
 import DefaultDragManager from './DragManager'
@@ -19,6 +18,7 @@ import DefaultMacroManager from './MacroManager'
 import DefaultMarkersManager from './MarkersManager'
 import DefaultSurfaceManager from './SurfaceManager'
 import DefaultSaveHandler from '../packages/persistence/SaveHandlerStub'
+import DefaultLabelProvider from './DefaultLabelProvider'
 
 /**
   Default Configurator for Substance editors. It provides an API for
@@ -540,10 +540,6 @@ class Configurator {
     return new FontAwesomeIconProvider(this.config.icons)
   }
 
-  getLabelProvider() {
-    return new LabelProvider(this.config.labels)
-  }
-
   getEditingBehavior() {
     var editingBehavior = new EditingBehavior()
     this.config.editingBehaviors.forEach(function(behavior) {
@@ -673,6 +669,19 @@ class Configurator {
   getSaveHandler() {
     let SaveHandler = this.config.SaveHandlerClass || DefaultSaveHandler
     return new SaveHandler()
+  }
+
+  getLabelProviderClass() {
+    return this.config.LabelProviderClass || DefaultLabelProvider
+  }
+
+  setLabelProviderClass(LabelProviderClass) {
+    this.config.LabelProviderClass = LabelProviderClass
+  }
+
+  getLabelProvider() {
+    const LabelProvider = this.getLabelProviderClass()
+    return new LabelProvider(this.config.labels)
   }
 
 }

--- a/ui/Configurator.js
+++ b/ui/Configurator.js
@@ -83,7 +83,7 @@ class Configurator {
       keyboardShortcuts: [],
       icons: {},
       labels: {},
-      lang: 'en_US',
+      lang: 'en',
       editorOptions: [],
       CommandManagerClass: DefaultCommandManager,
       DragManagerClass: DefaultDragManager,
@@ -593,7 +593,7 @@ class Configurator {
   }
 
   getDefaultLanguage() {
-    return this.config.lang || 'en_US'
+    return this.config.lang || 'en'
   }
 
   /* This is used for DependencyInjection of core implementations */

--- a/ui/DefaultLabelProvider.js
+++ b/ui/DefaultLabelProvider.js
@@ -2,6 +2,7 @@
  Default label provider implementation
 */
 class DefaultLabelProvider {
+
   constructor(labels, lang) {
     this.lang = lang || 'en'
     this.labels = labels
@@ -44,10 +45,6 @@ class DefaultLabelProvider {
     return vars
   }
 
-  hasLabel(name) {
-    let labels = this.labels[this.lang]
-    return Boolean(labels[name])
-  }
 }
 
 export default DefaultLabelProvider

--- a/ui/DefaultLabelProvider.js
+++ b/ui/DefaultLabelProvider.js
@@ -7,23 +7,27 @@ class DefaultLabelProvider {
     this.labels = labels
   }
 
-  getLabel(name, context) {
+  getLabel(name, params) {
     let labels = this.labels[this.lang]
     if (!labels) return name
     let rawLabel = labels[name] || name
     // If context is provided, resolve templates
-    if (context) {
-      return this._evalTemplate(rawLabel, context)
+    if (params) {
+      return this._evalTemplate(rawLabel, params)
     } else {
       return rawLabel
     }
   }
 
-  _evalTemplate(label, context) {
+  setLanguage(lang) {
+    this.lang = lang || 'en'
+  }
+
+  _evalTemplate(label, params) {
     let vars = this._extractVariables(label)
     vars.forEach((varName) => {
       let searchExp = new RegExp(`\\\${${varName}}`, 'g')
-      let replaceStr = context[varName]
+      let replaceStr = params[varName]
       label = label.replace(searchExp, replaceStr)
     })
     return label

--- a/ui/EditorSession.js
+++ b/ui/EditorSession.js
@@ -181,6 +181,10 @@ class EditorSession extends EventEmitter {
         return this.getCommandStates()
       case 'change':
         return this.getChange()
+      case 'lang':
+        return this.getLanguage()
+      case 'dir':
+        return this.getTextDirection()
       default:
         throw new Error('Unknown resource: ' + resourceName)
     }


### PR DESCRIPTION
In an earlier version of substance we supported i18n via label provider.
Somewhere on the way we have lost this functionality.
This PR is allowing to configure the LabelProvider implementation.
Custom parameters are supported (e.g., for supporting plurals or variables).