### PR TITLE
Append and remove child API for inline nodes.

### DIFF
--- a/xml/XMLElementNode.js
+++ b/xml/XMLElementNode.js
@@ -1,73 +1,40 @@
 import DOMElement from '../dom/DOMElement'
 import XMLDocumentNode from './XMLDocumentNode'
+import xmlNodeHelpers from './xmlNodeHelpers'
 
 export default
 class XMLElementNode extends XMLDocumentNode {
 
   appendChild(child) {
-    this.insertAt(this._childNodes.length, child)
+    xmlNodeHelpers.appendChild(this, child)
   }
 
   removeChild(child) {
-    const childId = child.id
-    const childPos = this._childNodes.indexOf(childId)
-    if (childPos >= 0) {
-      this.removeAt(childPos)
-    } else {
-      throw new Error(`node ${childId} is not a child of ${this.id}`)
-    }
-    return this
+    xmlNodeHelpers.removeChild(this, child)
   }
 
   insertBefore(newChild, ref) {
-    if (!ref) {
-      this.appendChild(newChild)
-    } else {
-      let pos = this._childNodes.indexOf(ref.id)
-      if (pos < 0) {
-        throw new Error('Given node is not a child.')
-      }
-      this.insertAt(pos, newChild)
-    }
+    xmlNodeHelpers.insertBefore(this, newChild, ref)
   }
 
   insertAt(pos, child) {
-    const length = this._childNodes.length
-    if (pos >= 0 && pos <= length) {
-      const doc = this.getDocument()
-      doc.update([this.id, '_childNodes'], { type: 'insert', pos, value: child.id })
-    } else {
-      throw new Error('Index out of bounds.')
-    }
-    return this
+    xmlNodeHelpers.insertAt(this, pos, child)
   }
 
   removeAt(pos) {
-    const length = this._childNodes.length
-    if (pos >= 0 && pos < length) {
-      const doc = this.getDocument()
-      doc.update([this.id, '_childNodes'], { type: 'delete', pos: pos })
-    } else {
-      throw new Error('Index out of bounds.')
-    }
-    return this
+    xmlNodeHelpers.removeAt(this, pos)
   }
 
   getInnerXML() {
-    return this.getChildren().map(child => {
-      return child.toXML().outerHTML
-    }).join('')
+    xmlNodeHelpers.getInnerXML(this)
+  }
+
+  getChildAt(idx) {
+    xmlNodeHelpers.getChildAt(this, idx)
   }
 
   isElementNode() {
     return true
-  }
-
-  getChildAt(idx) {
-    let childId = this._childNodes[idx]
-    if (childId) {
-      return this.getDocument().get(childId)
-    }
   }
 
   // TODO: implement as much of DOMElement as possible

--- a/xml/XMLInlineElementNode.js
+++ b/xml/XMLInlineElementNode.js
@@ -42,44 +42,6 @@ class XMLInlineElementNode extends XMLAnnotationNode {
     xmlNodeHelpers.insertAt(this, pos, child)
   }
 
-  // appendChild(child) {
-  //   this.insertAt(this._childNodes.length, child)
-  // }
-
-  // removeChild(child) {
-  //   const childId = child.id
-  //   const childPos = this._childNodes.indexOf(childId)
-  //   if (childPos >= 0) {
-  //     this.removeAt(childPos)
-  //   } else {
-  //     throw new Error(`node ${childId} is not a child of ${this.id}`)
-  //   }
-  //   return this
-  // }
-  //
-  // insertBefore(newChild, ref) {
-  //   if (!ref) {
-  //     this.appendChild(newChild)
-  //   } else {
-  //     let pos = this._childNodes.indexOf(ref.id)
-  //     if (pos < 0) {
-  //       throw new Error('Given node is not a child.')
-  //     }
-  //     this.insertAt(pos, newChild)
-  //   }
-  // }
-
-  // insertAt(pos, child) {
-  //   const length = this._childNodes.length
-  //   if (pos >= 0 && pos <= length) {
-  //     const doc = this.getDocument()
-  //     doc.update([this.id, '_childNodes'], { type: 'insert', pos, value: child.id })
-  //   } else {
-  //     throw new Error('Index out of bounds.')
-  //   }
-  //   return this
-  // }
-
   removeAt(pos) {
     xmlNodeHelpers.removeAt(this, pos)
   }

--- a/xml/XMLInlineElementNode.js
+++ b/xml/XMLInlineElementNode.js
@@ -40,6 +40,18 @@ class XMLInlineElementNode extends XMLAnnotationNode {
     return this
   }
 
+  insertBefore(newChild, ref) {
+    if (!ref) {
+      this.appendChild(newChild)
+    } else {
+      let pos = this._childNodes.indexOf(ref.id)
+      if (pos < 0) {
+        throw new Error('Given node is not a child.')
+      }
+      this.insertAt(pos, newChild)
+    }
+  }
+
   insertAt(pos, child) {
     const length = this._childNodes.length
     if (pos >= 0 && pos <= length) {
@@ -60,6 +72,19 @@ class XMLInlineElementNode extends XMLAnnotationNode {
       throw new Error('Index out of bounds.')
     }
     return this
+  }
+
+  getInnerXML() {
+    return this.getChildren().map(child => {
+      return child.toXML().outerHTML
+    }).join('')
+  }
+
+  getChildAt(idx) {
+    let childId = this._childNodes[idx]
+    if (childId) {
+      return this.getDocument().get(childId)
+    }
   }
 }
 

--- a/xml/XMLInlineElementNode.js
+++ b/xml/XMLInlineElementNode.js
@@ -25,6 +25,42 @@ class XMLInlineElementNode extends XMLAnnotationNode {
     this._parentNode = parent
   }
 
+  appendChild(child) {
+    this.insertAt(this._childNodes.length, child)
+  }
+
+  removeChild(child) {
+    const childId = child.id
+    const childPos = this._childNodes.indexOf(childId)
+    if (childPos >= 0) {
+      this.removeAt(childPos)
+    } else {
+      throw new Error(`node ${childId} is not a child of ${this.id}`)
+    }
+    return this
+  }
+
+  insertAt(pos, child) {
+    const length = this._childNodes.length
+    if (pos >= 0 && pos <= length) {
+      const doc = this.getDocument()
+      doc.update([this.id, '_childNodes'], { type: 'insert', pos, value: child.id })
+    } else {
+      throw new Error('Index out of bounds.')
+    }
+    return this
+  }
+
+  removeAt(pos) {
+    const length = this._childNodes.length
+    if (pos >= 0 && pos < length) {
+      const doc = this.getDocument()
+      doc.update([this.id, '_childNodes'], { type: 'delete', pos: pos })
+    } else {
+      throw new Error('Index out of bounds.')
+    }
+    return this
+  }
 }
 
 XMLInlineElementNode.prototype._elementType = 'inline-element'

--- a/xml/XMLInlineElementNode.js
+++ b/xml/XMLInlineElementNode.js
@@ -1,4 +1,5 @@
 import XMLAnnotationNode from './XMLAnnotationNode'
+import xmlNodeHelpers from './xmlNodeHelpers'
 
 export default
 class XMLInlineElementNode extends XMLAnnotationNode {
@@ -26,52 +27,61 @@ class XMLInlineElementNode extends XMLAnnotationNode {
   }
 
   appendChild(child) {
-    this.insertAt(this._childNodes.length, child)
+    xmlNodeHelpers.appendChild(this, child)
   }
 
   removeChild(child) {
-    const childId = child.id
-    const childPos = this._childNodes.indexOf(childId)
-    if (childPos >= 0) {
-      this.removeAt(childPos)
-    } else {
-      throw new Error(`node ${childId} is not a child of ${this.id}`)
-    }
-    return this
+    xmlNodeHelpers.removeChild(this, child)
   }
 
   insertBefore(newChild, ref) {
-    if (!ref) {
-      this.appendChild(newChild)
-    } else {
-      let pos = this._childNodes.indexOf(ref.id)
-      if (pos < 0) {
-        throw new Error('Given node is not a child.')
-      }
-      this.insertAt(pos, newChild)
-    }
+    xmlNodeHelpers.insertBefore(this, newChild, ref)
   }
 
   insertAt(pos, child) {
-    const length = this._childNodes.length
-    if (pos >= 0 && pos <= length) {
-      const doc = this.getDocument()
-      doc.update([this.id, '_childNodes'], { type: 'insert', pos, value: child.id })
-    } else {
-      throw new Error('Index out of bounds.')
-    }
-    return this
+    xmlNodeHelpers.insertAt(this, pos, child)
   }
 
+  // appendChild(child) {
+  //   this.insertAt(this._childNodes.length, child)
+  // }
+
+  // removeChild(child) {
+  //   const childId = child.id
+  //   const childPos = this._childNodes.indexOf(childId)
+  //   if (childPos >= 0) {
+  //     this.removeAt(childPos)
+  //   } else {
+  //     throw new Error(`node ${childId} is not a child of ${this.id}`)
+  //   }
+  //   return this
+  // }
+  //
+  // insertBefore(newChild, ref) {
+  //   if (!ref) {
+  //     this.appendChild(newChild)
+  //   } else {
+  //     let pos = this._childNodes.indexOf(ref.id)
+  //     if (pos < 0) {
+  //       throw new Error('Given node is not a child.')
+  //     }
+  //     this.insertAt(pos, newChild)
+  //   }
+  // }
+
+  // insertAt(pos, child) {
+  //   const length = this._childNodes.length
+  //   if (pos >= 0 && pos <= length) {
+  //     const doc = this.getDocument()
+  //     doc.update([this.id, '_childNodes'], { type: 'insert', pos, value: child.id })
+  //   } else {
+  //     throw new Error('Index out of bounds.')
+  //   }
+  //   return this
+  // }
+
   removeAt(pos) {
-    const length = this._childNodes.length
-    if (pos >= 0 && pos < length) {
-      const doc = this.getDocument()
-      doc.update([this.id, '_childNodes'], { type: 'delete', pos: pos })
-    } else {
-      throw new Error('Index out of bounds.')
-    }
-    return this
+    xmlNodeHelpers.removeAt(this, pos)
   }
 
   getInnerXML() {
@@ -81,10 +91,7 @@ class XMLInlineElementNode extends XMLAnnotationNode {
   }
 
   getChildAt(idx) {
-    let childId = this._childNodes[idx]
-    if (childId) {
-      return this.getDocument().get(childId)
-    }
+    xmlNodeHelpers.getChildAt(this, idx)
   }
 }
 

--- a/xml/xmlNodeHelpers.js
+++ b/xml/xmlNodeHelpers.js
@@ -1,0 +1,71 @@
+export default {
+  appendChild,
+  removeChild,
+  insertBefore,
+  insertAt,
+  removeAt,
+  getInnerXML,
+  getChildAt
+}
+
+function appendChild(xmlNode, child) {
+  insertAt(xmlNode, xmlNode._childNodes.length, child)
+}
+
+function removeChild(xmlNode, child) {
+  const childId = child.id
+  const childPos = xmlNode._childNodes.indexOf(childId)
+  if (childPos >= 0) {
+    removeAt(xmlNode, childPos)
+  } else {
+    throw new Error(`node ${childId} is not a child of ${xmlNode.id}`)
+  }
+  return xmlNode
+}
+
+function insertBefore(xmlNode, newChild, ref) {
+  if (!ref) {
+    appendChild(newChild)
+  } else {
+    let pos = xmlNode._childNodes.indexOf(ref.id)
+    if (pos < 0) {
+      throw new Error('Given node is not a child.')
+    }
+    insertAt(xmlNode, pos, newChild)
+  }
+}
+
+function insertAt(xmlNode, pos, child) {
+  const length = xmlNode._childNodes.length
+  if (pos >= 0 && pos <= length) {
+    const doc = xmlNode.getDocument()
+    doc.update([xmlNode.id, '_childNodes'], { type: 'insert', pos, value: child.id })
+  } else {
+    throw new Error('Index out of bounds.')
+  }
+  return xmlNode
+}
+
+function removeAt(xmlNode, pos) {
+  const length = xmlNode._childNodes.length
+  if (pos >= 0 && pos < length) {
+    const doc = xmlNode.getDocument()
+    doc.update([xmlNode.id, '_childNodes'], { type: 'delete', pos: pos })
+  } else {
+    throw new Error('Index out of bounds.')
+  }
+  return xmlNode
+}
+
+function getInnerXML(xmlNode) {
+  return xmlNode.getChildren().map(child => {
+    return child.toXML().outerHTML
+  }).join('')
+}
+
+function getChildAt(xmlNode, idx) {
+  let childId = xmlNode._childNodes[idx]
+  if (childId) {
+    return xmlNode.getDocument().get(childId)
+  }
+}


### PR DESCRIPTION
@oliver---- this is all I need regarding XML inline nodes API.
However there are couple of methods left in XMLElementNode.js which I didn't copied. It maybe a good idea to move them as well for XML API compatibility. What do you think?