### PR TITLE
Fix ES5 build

### DIFF
--- a/make.js
+++ b/make.js
@@ -95,7 +95,7 @@ function buildLib(target, production) {
       ]
     }
   }
-  if (target === 'legacy') {
+  if (target === 'browser:legacy') {
     config.buble = true
   }
   if (production) {


### PR DESCRIPTION
As mentioned in #1121, the ES5 build seems to be misconfigured. The `dist/substance.es5.js` file currently published to npm contains `class`, `const`, `let` and other incompatible features. This small fix puts `browser:legacy` builds through Bublé as (I think) intended.