### PR TITLE
Improvements

### DIFF
--- a/model/Node.js
+++ b/model/Node.js
@@ -197,11 +197,11 @@ function _compileSchema (schema) {
   let compiledSchema = {}
   forEach(schema, function (definition, name) {
     // skip 'type'
-    if (name === 'type') {
-      return
-    }
+    if (name === 'type') return
     if (isString(definition) || isArray(definition)) {
       definition = { type: definition }
+    } else {
+      definition = cloneDeep(definition)
     }
     definition = _compileDefintion(definition)
     definition.name = name
@@ -227,12 +227,13 @@ function _compileDefintion (definition) {
     let first = defs[0]
     let last = defs[lastIdx]
     let isCanonical = first === 'array'
-    let hasTargetType = last !== 'id' && !_isValueType(last)
-    definition.targetTypes = type
     if (isCanonical) {
       definition.type = defs.slice()
-      definition.type[lastIdx] = 'id'
-      if (hasTargetType) definition.targetTypes = [last]
+      // 'semi'-canonical
+      if (last !== 'id' && !_isValueType(last)) {
+        definition.targetTypes = [last]
+        definition.type[lastIdx] = 'id'
+      }
     } else {
       if (defs.length > 1) {
         defs.forEach(t => {
@@ -257,6 +258,7 @@ function _compileDefintion (definition) {
       default: '',
       _isText: true
     }
+  // single reference type
   } else if (type !== 'id' && !_isValueType(type)) {
     definition.type = 'id'
     definition.targetTypes = [type]

--- a/test/NodeSchema.test.js
+++ b/test/NodeSchema.test.js
@@ -23,7 +23,7 @@ test('properties of type ["object"] (#1169)', (t) => {
   t.end()
 })
 
-test('property with multiple reference types', (t) => {
+test('reference property with multiple target types', (t) => {
   class MyNode extends Node {}
   MyNode.schema = {
     type: 'my-node',
@@ -32,6 +32,21 @@ test('property with multiple reference types', (t) => {
   let property = MyNode.schema.getProperty('content')
   // props with default values are optional
   t.ok(property.isArray(), 'property should be an array type')
+  t.deepEqual(property.type, ['array', 'id'], 'property should have correct type')
+  t.deepEqual(property.targetTypes, ['foo', 'bar'], 'property should have targetTypes set')
+  t.end()
+})
+
+test('reference property with multiple target types (canonical notation)', (t) => {
+  class MyNode extends Node {}
+  MyNode.schema = {
+    type: 'my-node',
+    content: { type: ['array', 'id'], targetTypes: ['foo', 'bar'], default: [] }
+  }
+  let property = MyNode.schema.getProperty('content')
+  // props with default values are optional
+  t.ok(property.isArray(), 'property should be an array type')
+  t.ok(property.isReference(), 'property should be a reference type')
   t.deepEqual(property.type, ['array', 'id'], 'property should have correct type')
   t.deepEqual(property.targetTypes, ['foo', 'bar'], 'property should have targetTypes set')
   t.end()

--- a/ui/Component.js
+++ b/ui/Component.js
@@ -161,7 +161,7 @@ export default class Component extends EventEmitter {
     this.__foreignRefs__ = {}
 
     // action handlers added via `handleAction()` are stored here
-    this._actionHandlers = {}
+    this._actionHandlers = this.getActionHandlers()
 
     // setting props without triggering willReceiveProps
     this.props = props
@@ -178,6 +178,10 @@ export default class Component extends EventEmitter {
 
   setId () {
     throw new Error("'id' is readonly")
+  }
+
+  getActionHandlers () {
+    return {}
   }
 
   /**


### PR DESCRIPTION
- `Component.getActionHandlers()` allows to define action handlers without overriding the Component constructor
- Some fixes in Node schema compilation