### PR TITLE
Tidy up

### DIFF
--- a/deprecated/DeprecatedSelectionState.js
+++ b/deprecated/DeprecatedSelectionState.js
@@ -82,7 +82,7 @@ export default class DeprecatedSelectionState {
     }
     const propAnnos = getPropertyAnnotationsForSelection(doc, sel)
     propAnnos.forEach(_add)
-    if (propAnnos.length === 1 && propAnnos[0].isInline()) {
+    if (propAnnos.length === 1 && propAnnos[0].isInlineNode()) {
       this.isInlineNodeSelection = propAnnos[0].getSelection().equals(sel)
     }
     const containerId = sel.containerId

--- a/model/AnnotationIndex.js
+++ b/model/AnnotationIndex.js
@@ -6,7 +6,7 @@ import TreeIndex from '../util/TreeIndex'
 import DocumentIndex from './DocumentIndex'
 
 /*
-  Index for Annotations.
+  Index for Annotations and InlineNodes.
 
   @example
   Lets us look up existing annotations by path and type
@@ -20,7 +20,7 @@ import DocumentIndex from './DocumentIndex'
 
     aIndex.get(["text_1", "content"], 23, 45)
 */
-class AnnotationIndex extends DocumentIndex {
+export default class AnnotationIndex extends DocumentIndex {
   constructor () {
     super()
 
@@ -29,7 +29,7 @@ class AnnotationIndex extends DocumentIndex {
   }
 
   select (node) {
-    return node.isPropertyAnnotation()
+    return node.isPropertyAnnotation() || node.isInlineNode()
   }
 
   clear () {
@@ -95,5 +95,3 @@ AnnotationIndex.filterByRange = function (start, end) {
     return overlap
   }
 }
-
-export default AnnotationIndex

--- a/model/AnnotationMixin.js
+++ b/model/AnnotationMixin.js
@@ -99,19 +99,6 @@ export default function (DocumentNode) {
     }
 
     /**
-      If this annotation is an Anchor.
-
-      Anchors are annotations with a zero width.
-      For instance, ContainerAnnotation have a start and an end anchor,
-      or rendered cursors are modeled as anchors.
-
-      @returns {Boolean}
-    */
-    isAnchor () {
-      return false
-    }
-
-    /**
       Provides a selection which has the same range as this annotation.
 
       @return {model/ContainerSelection}
@@ -123,7 +110,7 @@ export default function (DocumentNode) {
         console.warn('Trying to use a ContainerAnnotation which is not attached to the document.')
         return Selection.nullSelection()
       }
-      if (this._isContainerAnnotation) {
+      if (this.isContainerAnnotation()) {
         return doc.createSelection({
           type: 'container',
           containerId: this.containerId,
@@ -172,9 +159,9 @@ export default function (DocumentNode) {
         throw new Error('Invalid selection.')
       }
     }
-  }
 
-  AbstractAnnotation.prototype._isAnnotation = true
+    static isAnnotation () { return true }
+  }
 
   AbstractAnnotation.schema = {
     start: { type: 'coordinate', default: { path: [], offset: 0 } },

--- a/model/BlockNode.js
+++ b/model/BlockNode.js
@@ -1,5 +1,5 @@
 import DocumentNode from './DocumentNode'
 
 export default class BlockNode extends DocumentNode {
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }

--- a/model/ContainerAnnotation.js
+++ b/model/ContainerAnnotation.js
@@ -39,11 +39,9 @@ export default class ContainerAnnotation extends AnnotationMixin(DocumentNode) {
     }
   }
 
-  // TODO: find out which of these we are really using
-  // and if we could get rid og them
-  get _isAnnotation () { return true }
+  static isAnnotation () { return true }
 
-  get _isContainerAnnotation () { return true }
+  static isContainerAnnotation () { return true }
 }
 
 ContainerAnnotation.schema = {

--- a/model/ContainerAnnotationIndex.js
+++ b/model/ContainerAnnotationIndex.js
@@ -4,7 +4,7 @@ import map from '../util/map'
 import TreeIndex from '../util/TreeIndex'
 import DocumentIndex from './DocumentIndex'
 
-class ContainerAnnotationIndex extends DocumentIndex {
+export default class ContainerAnnotationIndex extends DocumentIndex {
   constructor () {
     super()
     this.byId = new TreeIndex()
@@ -38,5 +38,3 @@ class ContainerAnnotationIndex extends DocumentIndex {
     // TODO should we support moving a container anno from one container to another?
   }
 }
-
-export default ContainerAnnotationIndex

--- a/model/ContainerMixin.js
+++ b/model/ContainerMixin.js
@@ -207,6 +207,10 @@ export default function (DocumentNode) {
     getChildCount () {
       return this.getContent().length
     }
+
+    static isContainer () {
+      return true
+    }
   }
   return AbstractContainer
 }

--- a/model/DOMImporter.js
+++ b/model/DOMImporter.js
@@ -438,6 +438,9 @@ export default class DOMImporter {
         var startOffset = context.offset
         const annoType = annoConverter.type
         const AnnoClass = this.schema.getNodeClass(annoType)
+        if (!AnnoClass) {
+          throw new Error(`No Node class registered for type ${annoType}.`)
+        }
         let annoData = this._createNodeData(el, annoType)
         // push a new context so we can deal with reentrant calls
         let stackFrame = {

--- a/model/DOMImporter.js
+++ b/model/DOMImporter.js
@@ -81,7 +81,9 @@ export default class DOMImporter {
       }
       this._allConverters.push(converter)
       // Defaults to _blockConverters
-      if (NodeClass.prototype._isPropertyAnnotation) {
+      // TODO: rename '_propertyAnnotationConverters' to 'inlineElementConverters'
+      // TODO: what about anchors and ContainerAnnotations?
+      if (NodeClass.isPropertyAnnotation() || NodeClass.isInlineNode()) {
         this._propertyAnnotationConverters.push(converter)
       } else {
         this._blockConverters.push(converter)
@@ -183,9 +185,9 @@ export default class DOMImporter {
       // usually, annotations are imported via `importer.annotatedText(..)`
       // The peculiarity here is that in such a case, it is not
       // not clear, which property the annotation should be attached to.
-      if (NodeClass.isInline) {
+      if (NodeClass.isInlineNode()) {
         nodeData = this._convertInlineNode(el, nodeData, converter)
-      } else if (NodeClass.prototype._isPropertyAnnotation) {
+      } else if (NodeClass.isPropertyAnnotation()) {
         nodeData = this._convertPropertyAnnotation(el, nodeData)
       } else {
         nodeData = converter.import(el, nodeData, this) || nodeData
@@ -455,7 +457,7 @@ export default class DOMImporter {
         // let the content be converted by custom implementations
         // as they do not own the content
         // TODO: we should make sure to throw when the user tries to
-        if (AnnoClass.isInline) {
+        if (AnnoClass.isInlineNode()) {
           this._customText(INVISIBLE_CHARACTER)
           // TODO: check if this is correct; after reading an inline,
           // we need to reset the lastChar, so that the next whitespace

--- a/model/Document.js
+++ b/model/Document.js
@@ -508,7 +508,7 @@ export default class Document extends EventEmitter {
     // not as children. So we assign level -1 to all annotations, meaning
     // that they are 'on-top-of' the content, and being created at the very last
     let level = 0
-    if (node.isAnnotation() || node.isInline()) {
+    if (node.isAnnotation() || node.isInlineNode()) {
       level = -1
     } else {
       let parent = node.getParent()

--- a/model/DocumentChange.js
+++ b/model/DocumentChange.js
@@ -85,7 +85,7 @@ class DocumentChange {
         }
         default:
           /* istanbul ignore next */
-          throw new Error('Illegal state')
+          // NOP
       }
     }
 

--- a/model/DocumentNode.js
+++ b/model/DocumentNode.js
@@ -131,59 +131,86 @@ class DocumentNode extends DataNode {
   // Node categories
   // --------------------
 
-  // TODO: we should use the same approach everywhere, either as prototype property or as class property
+  /**
+   * An anchor is an inline-node with zero-width.
+   */
+  isAnchor () {
+    return this.constructor.isAnchor()
+  }
 
   /**
-    @returns {Boolean} true if node is a block node (e.g. Paragraph, Figure, List, Table)
-  */
+   * An annotation has a `start` and an `end` coordinate that is used to anchor it within the document.
+   */
+  isAnnotation () {
+    return this.constructor.isAnnotation()
+  }
+
+  /**
+   * @returns {Boolean} true if node is a block node (e.g. Paragraph, Figure, List, Table)
+   */
   isBlock () {
-    return Boolean(this.constructor.isBlock)
+    // TODO: This category did not help too much.
+    // Find out if we can get rid of this. Essentially everything which is not an annotation or an inline node is a block
+    return this.constructor.isBlock()
+  }
+
+  /**
+   * A DocumentNode with a sequence of child nodes.
+   */
+  isContainer () {
+    return this.constructor.isContainer()
+  }
+
+  /**
+   * A ContainerAnnotation may span over multiple nodes, i.e. `start` and `end` may be located on different text nodes within a Container.
+   */
+  isContainerAnnotation () {
+    return this.constructor.isContainerAnnotation()
+  }
+
+  /**
+   * @returns {Boolean} true if node is an inline node (e.g. Inline Formula)
+   *
+   * > Attention: InlineNodes are substantially different to Annotations, as they **own** their content.
+   *  In contrast, annotations do not own the content, they are just 'overlays' to text owned by other nodes.
+   */
+  isInlineNode () {
+    return this.constructor.isInlineNode()
+  }
+
+  /**
+   * A DocumentNode used for modelling a List, consisting of a list of ListItems and a definition of ordering types.
+   */
+  isList () {
+    return this.constructor.isList()
+  }
+
+  /**
+   * A ListItem is may only be a direct child of a ListNode and should be a TextNode.
+   */
+  isListItem () {
+    return this.constructor.isListItem()
+  }
+
+  /**
+   * A PropertyAnnotation is an Annotation that is anchored to a single text property.
+   */
+  isPropertyAnnotation () {
+    return this.constructor.isPropertyAnnotation()
   }
 
   /**
     @returns {Boolean} true if node is a text node (e.g. Paragraph, Codebock)
   */
   isText () {
-    return Boolean(this.constructor.isText)
+    return this.constructor.isText()
   }
 
-  isList () {
-    return Boolean(this.constructor.isList)
-  }
+  // actual implementations are static
 
-  isListItem () {
-    return Boolean(this.constructor.isListItem)
-  }
+  static isAnchor () { return false }
 
-  isContainer () {
-    return Boolean(this._isContainer)
-  }
-
-  // annotation categories
-
-  isAnnotation () {
-    return Boolean(this._isAnnotation)
-  }
-
-  isPropertyAnnotation () {
-    return Boolean(this._isPropertyAnnotation)
-  }
-
-  isContainerAnnotation () {
-    return Boolean(this._isContainerAnnotation)
-  }
-
-  /**
-    @returns {Boolean} true if node is an inline node (e.g. Citation)
-  */
-  isInline () {
-    return Boolean(this.constructor.isInline)
-  }
-
-  // TODO: find out which of these properties are used anymore
-  // and try to get rid of them.
-
-  get _isDocumentNode () { return true }
+  static isAnnotation () { return false }
 
   /**
     Declares a node to be treated as block-type node.
@@ -191,33 +218,42 @@ class DocumentNode extends DataNode {
     BlockNodes are considers the direct descendant of `Container` nodes.
     @type {Boolean} default: false
   */
-  static get isBlock () { return false }
+  static isBlock () { return false }
 
-  /**
-    Declares a node to be treated as text-ish node.
-
-    @type {Boolean} default: false
-  */
-  static get isText () { return false }
-
-  /**
-    Declares a node to be treated as {@link model/PropertyAnnotation}.
-
-    @type {Boolean} default: false
-  */
-  static get isPropertyAnnotation () { return false }
+  static isContainer () { return false }
 
   /**
     Declares a node to be treated as {@link model/ContainerAnnotation}.
 
     @type {Boolean} default: false
   */
-  static get isContainerAnnotation () { return false }
+  static isContainerAnnotation () { return false }
 
   /**
-    Declares a node to be treated as {@link model/InlineNode}.
+   * Declares a node to be treated as {@link model/InlineNode}.
+   *
+   * @type {Boolean} default: false
+   */
+  static isInlineNode () { return false }
+
+  static isList () { return false }
+
+  static isListItem () { return false }
+
+  /**
+   * Declares a node to be treated as {@link model/PropertyAnnotation}.
+   *
+   * @type {Boolean} default: false
+   */
+  static isPropertyAnnotation () { return false }
+
+  /**
+    Declares a node to be treated as text-ish node.
 
     @type {Boolean} default: false
   */
-  static get isInline () { return false }
+  static isText () { return false }
+
+  // used for 'instanceof' comparison
+  get _isDocumentNode () { return true }
 }

--- a/model/Editing.js
+++ b/model/Editing.js
@@ -30,11 +30,11 @@ export default class Editing {
     // TODO: we need to generalize how node category can be derived statically
     /* istanbul ignore else  */
     if (sel.isPropertySelection()) {
-      if (!AnnotationClass.prototype._isAnnotation) {
+      if (!AnnotationClass.isAnnotation()) {
         throw new Error('Annotation can not be created for a selection.')
       }
     } else if (sel.isContainerSelection()) {
-      if (AnnotationClass.prototype._isPropertyAnnotation) {
+      if (AnnotationClass.isPropertyAnnotation()) {
         console.warn('NOT SUPPORTED YET: creating property annotations for a non collapsed container selection.')
       }
     }
@@ -751,7 +751,7 @@ export default class Editing {
       // they are deleted
       } else if (
         (annoStart >= startOffset && annoEnd < endOffset) ||
-        (anno._isInlineNode && annoStart >= startOffset && annoEnd <= endOffset)
+        (anno.isInlineNode() && annoStart >= startOffset && annoEnd <= endOffset)
       ) {
         tx.delete(anno.id)
       // IV anno.start between and anno.end after
@@ -770,7 +770,7 @@ export default class Editing {
         // skip
       // VII anno.start before and anno.end after
       } else if (annoStart < startOffset && annoEnd >= endOffset) {
-        if (anno._isInlineNode) {
+        if (anno.isInlineNode()) {
           // skip
         } else {
           tx.update([anno.id, 'end'], { type: 'shift', value: startOffset - endOffset + L })
@@ -798,7 +798,7 @@ export default class Editing {
     } else if (node.isList()) {
       this._breakListNode(tx, node, coor, container)
     } else {
-      throw new Error('Not supported')
+      console.error('FIXME: _breakNode() not supported for type', node.type)
     }
   }
 

--- a/model/Fragmenter.js
+++ b/model/Fragmenter.js
@@ -185,10 +185,10 @@ Fragmenter.ALWAYS_ON_TOP = Number.MAX_VALUE
 //
 
 function _extractEntries (annotations) {
-  var openers = []
-  var closers = []
+  let openers = []
+  let closers = []
   forEach(annotations, function (a) {
-    var isAnchor = (a.isAnchor ? a.isAnchor() : false)
+    let isAnchor = a.isAnchor()
     // special treatment for zero-width annos such as ContainerAnnotation.Anchors
     if (isAnchor) {
       openers.push({
@@ -212,7 +212,7 @@ function _extractEntries (annotations) {
 
       // use a weak default level when not given
       var l = Fragmenter.NORMAL
-      var isInline = (a.isInline ? a.isInline() : false)
+      var isInline = a.isInlineNode()
       if (isInline) {
         l = Number.MAX_VALUE
       } else if (a.constructor.hasOwnProperty('fragmentation')) {

--- a/model/InlineNode.js
+++ b/model/InlineNode.js
@@ -1,7 +1,6 @@
-import PropertyAnnotation from './PropertyAnnotation'
+import DocumentNode from './DocumentNode'
+import AnnotationMixin from './AnnotationMixin'
 
-export default class InlineNode extends PropertyAnnotation {
-  get _isInlineNode () { return true }
-
-  static get isInline () { return true }
+export default class InlineNode extends AnnotationMixin(DocumentNode) {
+  static isInlineNode () { return true }
 }

--- a/model/ListMixin.js
+++ b/model/ListMixin.js
@@ -5,10 +5,6 @@ const ERR_ABSTRACT = 'This method is abstract!'
 
 export default function (DocumentNode) {
   class AbstractList extends DocumentNode {
-    isList () {
-      return true
-    }
-
     createListItem (text) {
       throw new Error(ERR_ABSTRACT)
     }
@@ -102,6 +98,10 @@ export default function (DocumentNode) {
       if (oldListTypeString !== listTypeString) {
         this.setListTypeString(listTypeString)
       }
+    }
+
+    static isList () {
+      return true
     }
   }
 

--- a/model/PropertyAnnotation.js
+++ b/model/PropertyAnnotation.js
@@ -41,7 +41,7 @@ export default class PropertyAnnotation extends AnnotationMixin(DocumentNode) {
 
   get _isPropertyAnnotation () { return true }
 
-  static get isPropertyAnnotation () { return true }
+  static isPropertyAnnotation () { return true }
 
   static get autoExpandRight () { return true }
 }

--- a/model/TextBlock.js
+++ b/model/TextBlock.js
@@ -1,5 +1,5 @@
 import TextNode from './TextNode'
 
 export default class TextBlock extends TextNode {
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }

--- a/model/TextNode.js
+++ b/model/TextNode.js
@@ -13,7 +13,7 @@ export default class TextNode extends TextNodeMixin(DocumentNode) {
     return this.content
   }
 
-  static get isText () { return true }
+  static isText () { return true }
 }
 
 TextNode.schema = {

--- a/model/annotationHelpers.js
+++ b/model/annotationHelpers.js
@@ -32,7 +32,7 @@ function insertedText (doc, coordinate, length) {
     }
     // inline nodes do not expand automatically
     if ((pos < end) ||
-         (pos === end && !anno.isInline())) {
+         (pos === end && !anno.isInlineNode())) {
       newEnd += length
     }
     // TODO: Use coordintate ops!

--- a/packages/list/ListItemNode.js
+++ b/packages/list/ListItemNode.js
@@ -1,10 +1,6 @@
 import TextNode from '../../model/TextNode'
 
 export default class ListItem extends TextNode {
-  isListItem () {
-    return true
-  }
-
   getLevel () {
     return this.level
   }
@@ -14,10 +10,13 @@ export default class ListItem extends TextNode {
       this.getDocument().set([this.id, 'level'], newLevel)
     }
   }
+
+  static isListItem () {
+    return true
+  }
 }
 
-ListItem.type = 'list-item'
-
 ListItem.schema = {
+  type: 'list-item',
   level: { type: 'number', default: 1 }
 }

--- a/packages/list/ToggleListCommand.js
+++ b/packages/list/ToggleListCommand.js
@@ -23,7 +23,7 @@ export default class ToggleListCommand extends Command {
             listId,
             level
           }
-        } else if (node.isText() && node.isBlock) {
+        } else if (node.isText() && node.isBlock()) {
           return {
             disabled: false,
             action: 'switchTextType'

--- a/test/Fragmenter.test.js
+++ b/test/Fragmenter.test.js
@@ -132,7 +132,7 @@ class Anno extends PropertyAnnotation {
   constructor (tagName, id, startOffset, endOffset, opts) {
     super(null, {
       id: id,
-      start: { path: [id, 'content'], offset: startOffset},
+      start: { path: [id, 'content'], offset: startOffset },
       end: { path: [id, 'content'], offset: endOffset }
     })
 

--- a/test/fixture/TestInlineNode.js
+++ b/test/fixture/TestInlineNode.js
@@ -1,11 +1,8 @@
 import { InlineNode } from 'substance'
 
-class TestInlineNode extends InlineNode {}
-
-TestInlineNode.type = 'test-inline-node'
+export default class TestInlineNode extends InlineNode {}
 
 TestInlineNode.schema = {
+  type: 'test-inline-node',
   content: 'text'
 }
-
-export default TestInlineNode

--- a/test/fixture/TestNode.js
+++ b/test/fixture/TestNode.js
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'substance'
 
 export default class TestNode extends DocumentNode {
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }
 
 TestNode.schema = {

--- a/test/fixture/TestStructuredNode.js
+++ b/test/fixture/TestStructuredNode.js
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'substance'
 
 export default class StructuredNode extends DocumentNode {
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }
 
 StructuredNode.schema = {

--- a/ui/AnnotatedTextComponent.js
+++ b/ui/AnnotatedTextComponent.js
@@ -92,7 +92,7 @@ export default class AnnotatedTextComponent extends Component {
 
   _getFragmentComponentClass (node, noDefault) {
     let ComponentClass = this.getComponent(node.type, 'not-strict')
-    if (node.constructor.isInline &&
+    if (node.isInlineNode() &&
         // also no extra wrapping if the node is already an inline node
         !ComponentClass.prototype._isInlineNodeComponent &&
         // opt-out for custom implementations

--- a/ui/Command.js
+++ b/ui/Command.js
@@ -42,6 +42,7 @@ export default class Command {
     }
   }
 
+  // TODO: is this really used?
   get isAsync () {
     return false
   }

--- a/xml/XMLAnnotationNode.js
+++ b/xml/XMLAnnotationNode.js
@@ -1,8 +1,7 @@
 import AnnotationMixin from '../model/AnnotationMixin'
 import XMLDocumentNode from './XMLDocumentNode'
 
-export default
-class XMLAnnotationNode extends AnnotationMixin(XMLDocumentNode) {
+export default class XMLAnnotationNode extends AnnotationMixin(XMLDocumentNode) {
   /*
     The parent of an Annotation is implicitly given by its path.
   */
@@ -12,17 +11,12 @@ class XMLAnnotationNode extends AnnotationMixin(XMLDocumentNode) {
     return doc.get(path[0])
   }
 
-  isPropertyAnnotation () {
-    return true
-  }
+  static isPropertyAnnotation () { return true }
+
+  get _elementType () { return 'annotation' }
 }
 
-XMLAnnotationNode.prototype._elementType = 'annotation'
-
-// HACK: this is necessary so that DOMImporter registers convertes as annotation converters
-XMLAnnotationNode.prototype._isPropertyAnnotation = true
-
-XMLAnnotationNode.type = '@annotation'
-
 // schema inherited from mixin
-XMLAnnotationNode.schema = {}
+XMLAnnotationNode.schema = {
+  type: '@annotation'
+}

--- a/xml/XMLContainerNode.js
+++ b/xml/XMLContainerNode.js
@@ -20,7 +20,7 @@ export default class XMLContainerNode extends ContainerMixin(XMLElementNode) {
 
   get _elementType () { return 'container' }
 
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }
 
 XMLContainerNode.schema = {

--- a/xml/XMLElementNode.js
+++ b/xml/XMLElementNode.js
@@ -42,7 +42,7 @@ class XMLElementNode extends XMLDocumentNode {
 
   get _elementType () { return 'element' }
 
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }
 
 XMLElementNode.schema = {

--- a/xml/XMLExternalNode.js
+++ b/xml/XMLExternalNode.js
@@ -3,7 +3,7 @@ import XMLDocumentNode from './XMLDocumentNode'
 export default class XMLExternalNode extends XMLDocumentNode {
   get _elementType () { return 'external' }
 
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }
 
 XMLExternalNode.schema = {

--- a/xml/XMLInlineElementNode.js
+++ b/xml/XMLInlineElementNode.js
@@ -1,7 +1,8 @@
-import XMLAnnotationNode from './XMLAnnotationNode'
+import AnnotationMixin from '../model/AnnotationMixin'
+import XMLDocumentNode from './XMLDocumentNode'
 import * as xmlNodeHelpers from './xmlNodeHelpers'
 
-export default class XMLInlineElementNode extends XMLAnnotationNode {
+export default class XMLInlineElementNode extends AnnotationMixin(XMLDocumentNode) {
   /*
     Note: InlineElements can be used in structured context,
     If path is specified, parent is implicitly given.
@@ -54,11 +55,13 @@ export default class XMLInlineElementNode extends XMLAnnotationNode {
     }).join('')
   }
 
+  static isInlineNode () { return true }
+
   get _elementType () { return 'inline-element' }
 
-  // TODO: figure out which of these flags are really necessary
+  // this is used at some other places (DragManager, DOMExporter, Editing, AnnotatedTextComponent, xmlNodeHelpers)
+  // TODO: get rid of this by using `node.isInlineNode()` or `NodeClass.isInlineNode()`
   get _isInlineNode () { return true }
-  static get isInline () { return true }
 }
 
 XMLInlineElementNode.schema = {

--- a/xml/XMLTextElement.js
+++ b/xml/XMLTextElement.js
@@ -87,9 +87,9 @@ export default class XMLTextElement extends TextNodeMixin(XMLDocumentNode) {
 
   get _elementType () { return 'text' }
 
-  static get isText () { return true }
+  static isText () { return true }
 
-  static get isBlock () { return true }
+  static isBlock () { return true }
 }
 
 XMLTextElement.schema = {

--- a/xml/_analyzeSchema.js
+++ b/xml/_analyzeSchema.js
@@ -70,13 +70,9 @@ function _analyzeElementSchema (elementSchema, elementSchemas) {
       if (_hasText) childSchema.usedInlineBy[name] = true
     })
   })
-  // TODO: do we really need this?
-  if (hasElements) {
-    elementSchema.isStructured = true
-  }
-  if (hasText) {
-    elementSchema.isText = true
-  }
+  // TODO: document what these fields are used for.
+  if (hasElements) elementSchema.isStructured = true
+  if (hasText) elementSchema.isText = true
   if (elementSchema.type === 'implicit') {
     if (hasText) {
       elementSchema.type = 'text'

--- a/xml/xmlNodeHelpers.js
+++ b/xml/xmlNodeHelpers.js
@@ -141,7 +141,7 @@ function _renderTextNode (dom, node) {
     let fragmenter = new Fragmenter({
       onText: (context, text) => {
         const node = context.node
-        if (node.isText() || (node.isAnnotation() && !node._isInlineNode)) {
+        if (node.isText() || node.isAnnotation()) {
           context.el.append(text)
         }
       },


### PR DESCRIPTION
A more consistent implementation of Node category flags (e.g. node.isText())

Breaking change for code that introduces custom classes with old-style flags,
e.g., `MyNode.isBlock = true`

This can be resolved either by subclassing from the particular NodeClass, or using the method style notation:
```
MyNode.isBlock = () => { return true }
```
or better in es6:
```
class MyNode extends DocumentNode {
  static isBlock () { return true }
}
```
