### PR TITLE
Allow for targetTypes on TextProperties

### DIFF
--- a/model/Node.js
+++ b/model/Node.js
@@ -272,7 +272,8 @@ function _compileDefintion (definition) {
     result = {
       type: 'string',
       default: '',
-      _isText: true
+      _isText: true,
+      targetTypes: definition.targetTypes
     }
   // single reference type
   } else if (type !== 'id' && !_isValueType(type)) {

--- a/model/Schema.js
+++ b/model/Schema.js
@@ -72,8 +72,8 @@ export default class Schema {
     @param {String} name
     @returns {Class}
   */
-  getNodeClass (name) {
-    return this.nodeRegistry.get(name)
+  getNodeClass (name, strict) {
+    return this.nodeRegistry.get(name, strict)
   }
 
   /**


### PR DESCRIPTION
This way we can control which annotation types can be created on a text node.