### PR TITLE
Fix handling of <?xml> instruction

### DIFF
--- a/dom/BrowserDOMElement.js
+++ b/dom/BrowserDOMElement.js
@@ -339,8 +339,8 @@ class BrowserDOMElement extends DOMElement {
     return BrowserDOMElement.wrap(clone)
   }
 
-  createDocument (format) {
-    return BrowserDOMElement.createDocument(format)
+  createDocument (format, opts) {
+    return BrowserDOMElement.createDocument(format, opts)
   }
 
   createElement (tagName) {
@@ -648,11 +648,24 @@ class BrowserDOMElement extends DOMElement {
 BrowserDOMElement.prototype._isBrowserDOMElement = true
 
 // TODO: flesh out how options should look like (e.g. XML namespaceURI etc.)
-BrowserDOMElement.createDocument = function (format) {
+BrowserDOMElement.createDocument = function (format, opts = {}) {
   let doc
   if (format === 'xml') {
+    let xmlInstruction = []
+    if (opts.version) {
+      xmlInstruction.push(`version="${opts.version}"`)
+    }
+    if (opts.encoding) {
+      xmlInstruction.push(`encoding="${opts.encoding}"`)
+    }
+    let xmlStr
+    if (xmlInstruction.length > 0) {
+      xmlStr = `<?xml ${xmlInstruction.join(' ')}?><dummy/>`
+    } else {
+      xmlStr = `<dummy/>`
+    }
     // HACK: didn't find a way to create an empty XML doc without a root element
-    doc = window.document.implementation.createDocument(null, 'dummy')
+    doc = (new window.DOMParser()).parseFromString(xmlStr, 'application/xml')
     // remove the
     doc.removeChild(doc.firstChild)
   } else {

--- a/dom/DefaultDOMElement.js
+++ b/dom/DefaultDOMElement.js
@@ -7,8 +7,8 @@ import MemoryDOMElement from './MemoryDOMElement'
 */
 let DefaultDOMElement = {}
 
-DefaultDOMElement.createDocument = function (format) {
-  return _getDefaultImpl().createDocument(format)
+DefaultDOMElement.createDocument = function (format, opts) {
+  return _getDefaultImpl().createDocument(format, opts)
 }
 
 /* istanbul ignore next */

--- a/dom/MemoryDOMElement.js
+++ b/dom/MemoryDOMElement.js
@@ -664,9 +664,20 @@ export default class MemoryDOMElement extends DOMElement {
   // TODO: do we really need this?
   get _isMemoryDOMElement () { return true }
 
-  static createDocument (format) {
+  static createDocument (format, opts = {}) {
     if (format === 'xml') {
-      return new MemoryDOMElement('document', { format: format })
+      let doc = new MemoryDOMElement('document', { format: format })
+      let xmlInstruction = []
+      if (opts.version) {
+        xmlInstruction.push(`version="${opts.version}"`)
+      }
+      if (opts.encoding) {
+        xmlInstruction.push(`encoding="${opts.encoding}"`)
+      }
+      if (xmlInstruction.length > 0) {
+        doc._xmlInstruction = doc.createProcessingInstruction('xml', xmlInstruction.join(' '))
+      }
+      return doc
     } else {
       return MemoryDOMElement.parseMarkup(DOMElement.EMPTY_HTML, 'html')
     }

--- a/dom/MemoryDomUtils.js
+++ b/dom/MemoryDomUtils.js
@@ -423,7 +423,7 @@ export default class DomUtils {
   }
 
   renderDirective (elem) {
-    return '<?' + this.getData(elem) + '?>'
+    return '<?' + this.getName(elem) + ' ' + this.getData(elem) + '?>'
   }
 
   renderDoctype (elem) {

--- a/dom/MemoryDomUtils.js
+++ b/dom/MemoryDomUtils.js
@@ -363,6 +363,9 @@ export default class DomUtils {
       switch (elem.type) {
         case 'root':
         case 'document': {
+          if (elem._xmlInstruction) {
+            output.push(this.render(elem._xmlInstruction, opts))
+          }
           output.push(this.render(this.getChildren(elem), opts))
           break
         }

--- a/dom/parseMarkup.js
+++ b/dom/parseMarkup.js
@@ -129,8 +129,11 @@ class DomHandler {
   }
 
   onprocessinginstruction (name, data) {
-    // remove leading and trailing '?'
-    data = data.slice(1, -1)
+    // ATTENTION: this looks a bit hacky, but is essentially caused by the XML parser implementation
+    // remove leading '?${name}' and trailing '?'
+    data = data.slice(name.length, -1).trim()
+    // remove leading ?
+    name = name.slice(1)
     let element = this.document.createProcessingInstruction(name, data)
     this._addDomElement(element)
   }

--- a/dom/parseMarkup.js
+++ b/dom/parseMarkup.js
@@ -134,8 +134,12 @@ class DomHandler {
     data = data.slice(name.length, -1).trim()
     // remove leading ?
     name = name.slice(1)
-    let element = this.document.createProcessingInstruction(name, data)
-    this._addDomElement(element)
+    let el = this.document.createProcessingInstruction(name, data)
+    if (name === 'xml') {
+      this.document._xmlInstruction = el
+    } else {
+      this._addDomElement(el)
+    }
   }
 
   ondeclaration (data) {

--- a/model/XMLExporter.js
+++ b/model/XMLExporter.js
@@ -28,7 +28,11 @@ function _defaultConfig (config) {
     idAttribute: 'id'
   }, config)
   if (!config.elementFactory) {
-    config.elementFactory = DefaultDOMElement.createDocument('xml')
+    let xmlParams = {
+      version: config.xmlVersion || '1.0',
+      encoding: config.xmlEncoding || 'UTF-8'
+    }
+    config.elementFactory = DefaultDOMElement.createDocument('xml', xmlParams)
   }
   return config
 }

--- a/test/DOMElement.test.js
+++ b/test/DOMElement.test.js
@@ -663,6 +663,15 @@ function DOMElementTests (impl) {
     t.end()
   })
 
+  test('creating and serializing an XML document with xml instruction', t => {
+    let doc = DefaultDOMElement.createDocument('xml', { version: '1.0', encoding: 'UTF-8' })
+    doc.append(doc.createElement('dummy'))
+    let actual = doc.serialize()
+    let expected = '<?xml version="1.0" encoding="UTF-8"?><dummy/>'
+    t.equal(actual, expected, 'serialized xml should contain xml instruction')
+    t.end()
+  })
+
   test('doctype should be serialized (XML)', t => {
     let doc = DefaultDOMElement.createDocument('xml')
     doc.setDoctype('foo', 'Foo 1.0', 'http://schema.org/foo.dtd')

--- a/test/prettyPrintXML.test.js
+++ b/test/prettyPrintXML.test.js
@@ -25,17 +25,6 @@ function prettyPrintTests (impl) {
     t.end()
   })
 
-  test('dont render duplicate XML declaration', t => {
-    let xmlStr = `<article />`
-    let dom = DefaultDOMElement.parseXML(xmlStr)
-    let xmlInstruction = dom.createProcessingInstruction('xml', 'version="1.0" encoding="UTF-8"')
-    dom.insertAt(0, xmlInstruction)
-    let expected = `<?xml version="1.0" encoding="UTF-8"?>\n<article />`
-    let actual = prettyPrintXML(dom)
-    t.equal(actual, expected, 'prettyPrinted XML should be correct')
-    t.end()
-  })
-
   test('preserve DOCTYPE declaration', t => {
     let xmlStr = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD v1.0 20120330//EN" "JATS-journalarchiving.dtd"><article />`
     let expected = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD v1.0 20120330//EN" "JATS-journalarchiving.dtd">\n<article />`

--- a/test/prettyPrintXML.test.js
+++ b/test/prettyPrintXML.test.js
@@ -1,5 +1,5 @@
 import { module } from 'substance-test'
-import { platform, prettyPrintXML } from 'substance'
+import { platform, prettyPrintXML, DefaultDOMElement } from 'substance'
 
 if (platform.inBrowser) {
   prettyPrintTests('BrowserDOMElement')
@@ -24,6 +24,18 @@ function prettyPrintTests (impl) {
     t.equal(actual, expected, 'prettyPrinted XML should be correct')
     t.end()
   })
+
+  test('dont render duplicate XML declaration', t => {
+    let xmlStr = `<article />`
+    let dom = DefaultDOMElement.parseXML(xmlStr)
+    let xmlInstruction = dom.createProcessingInstruction('xml', 'version="1.0" encoding="UTF-8"')
+    dom.insertAt(0, xmlInstruction)
+    let expected = `<?xml version="1.0" encoding="UTF-8"?>\n<article />`
+    let actual = prettyPrintXML(dom)
+    t.equal(actual, expected, 'prettyPrinted XML should be correct')
+    t.end()
+  })
+
   test('preserve DOCTYPE declaration', t => {
     let xmlStr = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD v1.0 20120330//EN" "JATS-journalarchiving.dtd"><article />`
     let expected = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD v1.0 20120330//EN" "JATS-journalarchiving.dtd">\n<article />`
@@ -31,6 +43,7 @@ function prettyPrintTests (impl) {
     t.equal(actual, expected, 'prettyPrinted XML should be correct')
     t.end()
   })
+
   test('skip white-space outside the root element', t => {
     let xmlStr = `<?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD v1.0 20120330//EN" "JATS-journalarchiving.dtd">
@@ -40,6 +53,7 @@ function prettyPrintTests (impl) {
     t.equal(actual, expected, 'prettyPrinted XML should be correct')
     t.end()
   })
+
   test('layout structural elements', t => {
     let xmlStr = `<?xml version="1.0" encoding="UTF-8"?><article><front><title /></front><body><p /></body><back><references /></back></article>`
     let actual = prettyPrintXML(xmlStr)
@@ -58,6 +72,7 @@ function prettyPrintTests (impl) {
     t.equal(actual, expected, 'prettyPrinted XML should be correct')
     t.end()
   })
+
   test('layout mixed elements', t => {
     let xmlStr = `<?xml version="1.0" encoding="UTF-8"?><article><front><title>Hello <b>World</b>!</title></front><body><p>Bla blupp</p></body></article>`
     let actual = prettyPrintXML(xmlStr)

--- a/xml/XMLDocument.js
+++ b/xml/XMLDocument.js
@@ -23,8 +23,6 @@ class XMLDocument extends Document {
   toXML () {
     let dom = DefaultDOMElement.createDocument('xml')
     dom.setDoctype(...this.getDocTypeParams())
-    let xml = dom.createProcessingInstruction('xml', 'version="1.0" encoding="UTF-8"')
-    dom.insertAt(0, xml)
     let rootElement = this.getRootNode().toXML()
     dom.append(rootElement)
     return dom

--- a/xml/prettyPrintXML.js
+++ b/xml/prettyPrintXML.js
@@ -14,11 +14,19 @@ export default function prettyPrintXML (xml) {
     dom = xml
   }
   const result = []
-  if (dom._isBrowserDOMElement && dom.isDocumentNode()) {
-    // TODO: this should not be hard-coded but come from the DOM
-    result.push('<?xml version="1.0" encoding="UTF-8"?>')
+  // Note: the browser treats XML instructions in a surprising way:
+  // parsing `<?xml version="1.0" encoding="UTF-8"?><dummy/>` results in only one element
+  // i.e. the instruction is swallowed and stored in a way that it is created during serialization.
+  // Interestingly, this is not the case for the DOCTYPE declaration.
+  // ATTENTION: we have assimilated the MemoryDOM implementation, so that we get the same result.
+  let childNodes = dom.getChildNodes()
+  if (dom.isDocumentNode()) {
+    let xml = dom.empty().serialize()
+    if (/<\?\s*xml/.exec(xml)) {
+      result.push(xml)
+    }
   }
-  dom.childNodes.forEach((el) => {
+  childNodes.forEach(el => {
     _prettyPrint(result, el, 0)
   })
   return result.join('\n')


### PR DESCRIPTION
# Why?

The browser treats `<?xml>` instructions in a very 'special' way. In contrast to `<!DOCType>`, xml instructions can only be set via parsing. The instruction node does not appear in the childNodes, in contrast to the doctype declaration.

# What?

This PR assimilates the MemoryDOM implementation w.r.t xml instructions, and changes several related implementations (e.g. prettyPrintXML) to deal with this consistently.