### PR TITLE
Prevent scroll on focus

### DIFF
--- a/dom/BrowserDOMElement.js
+++ b/dom/BrowserDOMElement.js
@@ -560,8 +560,8 @@ class BrowserDOMElement extends DOMElement {
     return this.el.childNodes.length
   }
 
-  focus () {
-    this.el.focus()
+  focus (opts) {
+    this.el.focus(opts)
     return this
   }
 

--- a/ui/Surface.js
+++ b/ui/Surface.js
@@ -597,7 +597,7 @@ export default class Surface extends Component {
       this._state.skipNextFocusEvent = true
       // ATTENTION: unfortunately, focusing the contenteditable does lead to auto-scrolling
       // in some browsers
-      this.el.focus()
+      this.el.focus({ preventScroll: true })
       this._state.skipNextFocusEvent = false
     }
   }


### PR DESCRIPTION
# Why ?

An unused option can prevent auto-scrolling when an element gets focused: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus

# What ?

This PR changes BrowserDOMElement.focus() to pass through options to the native DOM element.
Surface makes use of this option.