### PR TITLE
Container properties

### DIFF
--- a/model/NodeProperty.js
+++ b/model/NodeProperty.js
@@ -30,6 +30,10 @@ export default class NodeProperty {
     return Boolean(this.definition._isText)
   }
 
+  isContainer () {
+    return Boolean(this.definition._isContainer)
+  }
+
   isOwned () {
     return Boolean(this.definition.owned)
   }

--- a/model/schemaHelpers.js
+++ b/model/schemaHelpers.js
@@ -1,4 +1,5 @@
 import flatten from '../util/flatten'
+import isString from '../util/isString'
 
 export const STRING = { type: 'string', default: '' }
 
@@ -13,26 +14,44 @@ export const STRING_ARRAY = { type: ['array', 'string'], default: [] }
 
 export const BOOLEAN = { type: 'boolean', default: false }
 
-export function MANY (...targetTypes) {
-  targetTypes = flatten(targetTypes)
-  return { type: ['array', 'id'], targetTypes, default: [] }
+export function MANY (...nodeTypes) {
+  nodeTypes = flatten(nodeTypes)
+  return { type: ['array', 'id'], targetTypes: nodeTypes, default: [] }
 }
 
-export function ONE (...targetTypes) {
-  targetTypes = flatten(targetTypes)
-  return { type: 'id', targetTypes, default: null }
+export function ONE (...nodeTypes) {
+  nodeTypes = flatten(nodeTypes)
+  return { type: 'id', targetTypes: nodeTypes, default: null }
 }
 
-export function CHILDREN (...targetTypes) {
-  targetTypes = flatten(targetTypes)
-  return { type: ['array', 'id'], targetTypes, default: [], owned: true }
+export function CHILDREN (...nodeTypes) {
+  nodeTypes = flatten(nodeTypes)
+  return { type: ['array', 'id'], targetTypes: nodeTypes, default: [], owned: true }
 }
 
 // EXPERIMENTAL: similar to CHILDREN but only a single id, e.g. figure.content -> graphic
 // for now we make this non-optional
-export function CHILD (...targetTypes) {
-  targetTypes = flatten(targetTypes)
-  return { type: 'id', targetTypes, owned: true }
+export function CHILD (...nodeTypes) {
+  nodeTypes = flatten(nodeTypes)
+  return { type: 'id', targetTypes: nodeTypes, owned: true }
+}
+
+export function CONTAINER (spec) {
+  let nodeTypes, defaultTextType
+  // convenience: only one text type
+  if (isString(spec)) {
+    nodeTypes = [spec]
+    defaultTextType = spec
+  // general
+  } else {
+    ({ nodeTypes, defaultTextType } = spec)
+  }
+  if (!nodeTypes) throw new Error('CONTAINER({ nodeTypes: [...] }) is mandatory.')
+  if (!defaultTextType) throw new Error('CONTAINER({ defaultTextType: [...] }) is mandatory.')
+  let def = CHILDREN(...nodeTypes)
+  def.defaultTextType = defaultTextType
+  def._isContainer = true
+  return def
 }
 
 export function OPTIONAL (type) {


### PR DESCRIPTION
Recently we generalized the internal implementation to support container properties, as opposed to container nodes.

This PR introduces a helper to define container properties in the schema.