### PR TITLE
Improvements

### DIFF
--- a/model/Editing.js
+++ b/model/Editing.js
@@ -545,7 +545,7 @@ export default class Editing {
     let nodeId = path[0]
     let node = tx.get(nodeId)
     /* istanbul ignore next */
-    if (!(node.isInstanceOf('text'))) {
+    if (!(node.isText())) {
       throw new Error('Trying to use switchTextType on a non text node.')
     }
     const newId = uuid(data.type)

--- a/model/TextNode.js
+++ b/model/TextNode.js
@@ -17,7 +17,7 @@ export default class TextNode extends TextNodeMixin(DocumentNode) {
 }
 
 TextNode.schema = {
-  type: 'text',
+  type: 'text-node',
   content: 'text',
   direction: { type: 'string', optional: true },
   textAlign: { type: 'string', default: 'left' }

--- a/test/IsolatedNode.test.js
+++ b/test/IsolatedNode.test.js
@@ -108,7 +108,7 @@ test("IsolatedNode: Issue #696: IsolatedNode should detect 'co-focused' robustly
   // by using startsWith on the surface path. This was leading to wrong
   // co-focused states when e.g. two isolated nodes `body/entity` and `body/entity-1`
   // exist. I.e. one surfaceId was a prefix of another one.
-  let { editorSession, editor } = setupEditor(t, _twoStructuredNodes)
+  let { editorSession, editor } = setupEditor(t, TWO_STRUCTURED_NODES)
   let isolatedNodes = editor.findAll('.sc-isolated-node')
   editorSession.setSelection({
     type: 'property',
@@ -124,6 +124,24 @@ test("IsolatedNode: Issue #696: IsolatedNode should detect 'co-focused' robustly
   t.end()
 })
 
+test('IsolatedNode: Click on an IsolatedNode should select the node', t => {
+  let { editor, editorSession } = setupEditor(t, TWO_STRUCTURED_NODES)
+  let isolatedNode = editor.find('.sc-isolated-node[data-id="sn"]')
+  // make sure there is no selection in the beginning
+  editorSession.setSelection(null)
+  // click on the isolatedNode
+  _clickOnIsolatedNode(isolatedNode)
+  let sel = editorSession.getSelection()
+  t.deepEqual({
+    type: sel.type,
+    nodeId: sel.nodeId
+  }, {
+    type: 'node',
+    nodeId: 'sn'
+  }, 'node should be selected')
+  t.end()
+})
+
 function _notSelected (t, isolated) {
   t.ok(isolated.isNotSelected(), "isolated node '" + isolated.getId() + "' should not be selected.")
 }
@@ -133,7 +151,13 @@ function _modeOk (t, isolated, expected) {
   t.looseEqual(isolated.getMode(), expected[id], "mode of isolated node '" + id + "' should be correct")
 }
 
-function _twoStructuredNodes (doc) {
+function _clickOnIsolatedNode (comp) {
+  // TODO: it might be better to have the click handler on the IsolatedNodeComponent instead of the blocker
+  // e.g. also works when used without blocker
+  comp.refs.blocker.el.click()
+}
+
+function TWO_STRUCTURED_NODES (doc) {
   let body = doc.get('body')
   body.append(doc.create({
     type: 'structured-node',

--- a/ui/IsolatedInlineNodeComponent.js
+++ b/ui/IsolatedInlineNodeComponent.js
@@ -78,16 +78,21 @@ export default class IsolatedInlineNodeComponent extends AbstractIsolatedNodeCom
   selectNode () {
     // console.log('IsolatedNodeComponent: selecting node.');
     const editorSession = this.getEditorSession()
-    const surface = this.getParentSurface()
     const node = this.props.node
-    editorSession.setSelection({
+    let selData = {
       type: 'property',
       path: node.start.path,
       startOffset: node.start.offset,
-      endOffset: node.end.offset,
-      containerPath: surface.getContainerPath(),
-      surfaceId: surface.id
-    })
+      endOffset: node.end.offset
+    }
+    const surface = this.getParentSurface()
+    if (surface) {
+      Object.assign(selData, {
+        containerPath: surface.getContainerPath(),
+        surfaceId: surface.id
+      })
+    }
+    editorSession.setSelection(selData)
   }
 
   _getContentClass () {

--- a/ui/IsolatedNodeComponent.js
+++ b/ui/IsolatedNodeComponent.js
@@ -92,14 +92,19 @@ export default class IsolatedNodeComponent extends AbstractIsolatedNodeComponent
   selectNode () {
     // console.log('IsolatedNodeComponent: selecting node.');
     const editorSession = this.getEditorSession()
-    const surface = this.getParentSurface()
     const nodeId = this.props.node.id
-    editorSession.setSelection({
+    let selData = {
       type: 'node',
-      nodeId: nodeId,
-      containerPath: surface.getContainerPath(),
-      surfaceId: surface.id
-    })
+      nodeId: nodeId
+    }
+    const surface = this.getParentSurface()
+    if (surface) {
+      Object.assign(selData, {
+        containerPath: surface.getContainerPath(),
+        surfaceId: surface.id
+      })
+    }
+    editorSession.setSelection(selData)
   }
 
   // EXPERIMENTAL: trying to catch clicks not handled by the


### PR DESCRIPTION
- Base-class TextNode has type='text-node'
- more robust implementation in `IsolatedNodeComponent.selectNode()`